### PR TITLE
FEATURE: Improve softdelete

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,20 +180,20 @@ const Order = mongoose.model<IOrder>('Order', orderSchema);
 
 ## Configuration Options
 
-| Option             | Type    | Default      | Description                                                                                                                                            |
-| ------------------ | ------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `modelName`        | string  | model name   | Model identification (REQUIRED)                                                                                                                        |
-| `modelKeyId`       | string  | `_id`        | ID key that identifies the model                                                                                                                       |
-| `softDelete`       | object  |              | Soft delete config: `{ field, value }`. When the specified field is set to the given value, the plugin logs a `delete` operation instead of an update. |
-| `contextFields`    | array   |              | Extra fields to include in the log context (array of field paths from the document itself; must be an array at the plugin level)                       |
-| `singleCollection` | boolean | `false`      | Use a single log collection for all models (`log_histories`)                                                                                           |
-| `saveWholeDoc`     | boolean | `false`      | Save full original/updated docs in the log                                                                                                             |
-| `maxBatchLog`      | number  | `1000`       | Max number of logs per batch operation                                                                                                                 |
-| `batchSize`        | number  | `100`        | Number of documents to process per batch in bulk hooks                                                                                                 |
-| `logger`           | object  | `console`    | Custom logger object (must support `.error` and `.warn` methods)                                                                                       |
-| `trackedFields`    | array   | `[]`         | Array of field configs to track (see below)                                                                                                            |
-| `userField`        | string  | `created_by` | The field in the document to extract user info from (dot notation supported). Value can be any type (object, string, ID, etc.).                        |
-| `compressDocs`     | boolean | `false`      | Compress `original_doc` and `updated_doc` using gzip.                                                                                                  |
+| Option             | Type            | Default      | Description                                                                                                                                            |
+| ------------------ | --------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `modelName`        | string          | model name   | Model identification (REQUIRED)                                                                                                                        |
+| `modelKeyId`       | string          | `_id`        | ID key that identifies the model                                                                                                                       |
+| `softDelete`       | object/function |              | Soft delete config: `{ field, value }`. When the specified field is set to the given value, the plugin logs a `delete` operation instead of an update. |
+| `contextFields`    | array           |              | Extra fields to include in the log context (array of field paths from the document itself; must be an array at the plugin level)                       |
+| `singleCollection` | boolean         | `false`      | Use a single log collection for all models (`log_histories`)                                                                                           |
+| `saveWholeDoc`     | boolean.        | `false`      | Save full original/updated docs in the log                                                                                                             |
+| `maxBatchLog`      | number          | `1000`       | Max number of logs per batch operation                                                                                                                 |
+| `batchSize`        | number          | `100`        | Number of documents to process per batch in bulk hooks                                                                                                 |
+| `logger`           | object          | `console`    | Custom logger object (must support `.error` and `.warn` methods)                                                                                       |
+| `trackedFields`    | array           | `[]`         | Array of field configs to track (see below)                                                                                                            |
+| `userField`        | string          | `created_by` | The field in the document to extract user info from (dot notation supported). Value can be any type (object, string, ID, etc.).                        |
+| `compressDocs`     | boolean         | `false`      | Compress `original_doc` and `updated_doc` using gzip.                                                                                                  |
 
 ---
 
@@ -221,6 +221,7 @@ The `softDelete` option allows you to track "soft deletes"—where a document is
 
 - `field`: The name of the field that indicates deletion (e.g., `"status"` or `"is_deleted"`).
 - `value`: The value that means the document is considered deleted (e.g., `"deleted"` or `true`).
+- (doc: unknown): boolean : A function that takes the document and returns true if it was soft-deleted.
 
 **Example:**
 
@@ -232,6 +233,14 @@ softDelete: {
 ```
 
 When you update a document and set `status` to `'deleted'`, the plugin will log this as a `delete` operation in the history.
+
+**Example function:**
+
+The `softDelete` option can also be a function that returns true if the document was soft deleted or not.
+
+```js
+softDelete: function(doc) { return doc.deletedAt !== undefined ; }
+```
 
 ---
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -155,7 +155,7 @@ export class ChangeLogPlugin {
   public readonly modelKeyId: string;
   public readonly trackedFields: TrackedField[];
   public readonly contextFields: string[];
-  public readonly softDelete: ((value: unknown) => boolean) | null;
+  public readonly softDelete: ((value: Record<string, unknown>) => boolean) | null;
   public readonly singleCollection: boolean;
   public readonly saveWholeDoc: boolean;
   public readonly maxBatchLog: number;
@@ -177,8 +177,7 @@ export class ChangeLogPlugin {
       } else {
         const softDelete = options.softDelete;
 
-        this.softDelete = (doc: unknown) =>
-          getValueByPath(doc as Record<string, unknown>, softDelete.field) === softDelete.value;
+        this.softDelete = (doc: Record<string, unknown>) => getValueByPath(doc, softDelete.field) === softDelete.value;
       }
     } else {
       this.softDelete = null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,7 @@ export type SoftDeleteConfig =
       /** The value that indicates a document is soft deleted */
       value: unknown;
     }
-  | ((doc: unknown) => boolean);
+  | ((doc: Record<string, unknown>) => boolean);
 
 /**
  * Context fields configuration for extracting additional metadata.

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,12 +27,14 @@ export interface Logger {
 /**
  * Soft delete configuration for detecting delete operations.
  */
-export interface SoftDeleteConfig {
-  /** The field path to check for soft delete status */
-  field: string;
-  /** The value that indicates a document is soft deleted */
-  value: unknown;
-}
+export type SoftDeleteConfig =
+  | {
+      /** The field path to check for soft delete status */
+      field: string;
+      /** The value that indicates a document is soft deleted */
+      value: unknown;
+    }
+  | ((doc: unknown) => boolean);
 
 /**
  * Context fields configuration for extracting additional metadata.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -355,7 +355,14 @@ export function validatePluginOptions(options: PluginOptions & { modelName: stri
   }
 
   if (options.softDelete) {
-    if (typeof options.softDelete.field !== 'string' || options.softDelete.value === undefined) {
+    if (typeof options.softDelete !== 'object' && typeof options.softDelete !== 'function') {
+      throw new Error('[mongoose-log-history] "softDelete" must be an object or a function.');
+    }
+
+    if (
+      typeof options.softDelete === 'object' &&
+      (typeof options.softDelete.field !== 'string' || options.softDelete.value === undefined)
+    ) {
       throw new Error('[mongoose-log-history] "softDelete" must be an object with "field" (string) and "value".');
     }
   }

--- a/test/integration/softDelete.integration.test.js
+++ b/test/integration/softDelete.integration.test.js
@@ -2,7 +2,10 @@ require('../setup/mongodb');
 const mongoose = require('mongoose');
 const { changeLoggingPlugin, getLogHistoryModel } = require('../../dist');
 
-describe('mongoose-log-history plugin - Soft Delete', () => {
+describe.each([
+  { softDelete: { field: 'status', value: 'deleted' }, testCase: 'object config' },
+  { softDelete: (doc) => doc.status === 'deleted', testCase: 'function config' },
+])('mongoose-log-history plugin - Soft Delete with $testCase', (options) => {
   let Order;
   let LogHistory;
 
@@ -16,11 +19,8 @@ describe('mongoose-log-history plugin - Soft Delete', () => {
       modelName: 'Order',
       trackedFields: [{ value: 'status' }],
       singleCollection: true,
-      softDelete: {
-        field: 'status',
-        value: 'deleted',
-      },
       maxBatchLog: 5,
+      softDelete: options.softDelete,
     });
 
     Order = mongoose.model('Order', orderSchema);
@@ -30,6 +30,10 @@ describe('mongoose-log-history plugin - Soft Delete', () => {
   afterEach(async () => {
     await Order.deleteMany({});
     await LogHistory.deleteMany({});
+  });
+
+  afterAll(() => {
+    mongoose.deleteModel('Order');
   });
 
   const wait = () => new Promise((resolve) => setTimeout(resolve, 100));


### PR DESCRIPTION
Resolves https://github.com/granitebps/mongoose-log-history/issues/12

Adds a feature to allow softDelete to be a function:

```ts
/**
 * Soft delete configuration for detecting delete operations.
 */
export type SoftDeleteConfig =
  | {
      /** The field path to check for soft delete status */
      field: string;
      /** The value that indicates a document is soft deleted */
      value: unknown;
    }
  | ((doc: Record<string, unknown>) => boolean);
```

Example Usage:
```
 orderSchema.plugin(changeLoggingPlugin, {
      modelName: 'Order',
      trackedFields: [{ value: 'status' }],
      softDelete: (doc: Record<string, unknown>) => !!doc.deletedAt,
    });
```

Here, softDelete will return true if the document's `deletedAt` field is truthy.  Here, `deletedAt` is a `Date` and cannot be used with the current `{field: string; value: unknown}` softDelete feature.

Note: I tried an attempt to update the readme, let me know if any updates needed.