### PR TITLE
FEATURE: support maskedValue for private fields

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,12 @@ export interface TrackedField {
    */
   valueField?: string;
 
+  /**
+   * When defined, the value for this field field is masked in the logs.
+   * This is useful for sensitive information that should not be stored in logs.
+   */
+  maskedValue?: string | ((value: unknown) => string | null | undefined);
+
   /** Additional context fields to include in logs for this specific field */
   contextFields?: ContextFields;
 
@@ -258,6 +264,11 @@ export interface LogHistoryDocument extends Omit<Document, 'model'> {
 export interface LogHistoryModel extends Model<LogHistoryDocument> {}
 
 /**
+ * A mapping of field paths to their masked values or masking functions.
+ */
+export type MaskedValues = Record<string, string | ((value: unknown) => string | null | undefined)>;
+
+/**
  * Parameters for building a log entry.
  */
 export interface BuildLogEntryParams {
@@ -271,6 +282,7 @@ export interface BuildLogEntryParams {
   context?: Record<string, unknown>;
   saveWholeDoc?: boolean;
   compressDocs?: boolean;
+  maskedValues?: MaskedValues;
 }
 
 /**

--- a/test/integration/maskedValues.integration.test.js
+++ b/test/integration/maskedValues.integration.test.js
@@ -1,0 +1,356 @@
+require('../setup/mongodb');
+const mongoose = require('mongoose');
+const { changeLoggingPlugin, getLogHistoryModel } = require('../../dist');
+
+describe('mongoose-log-history plugin - Masked Values', () => {
+  let Order;
+  let LogHistory;
+
+  beforeAll(() => {
+    const orderSchema = new mongoose.Schema({
+      name: String,
+      tags: [String],
+      subdoc: {
+        secret: String,
+        plain: String,
+      },
+    });
+
+    orderSchema.plugin(changeLoggingPlugin, {
+      modelName: 'Order',
+      trackedFields: [
+        { value: 'name', maskedValue: '***' },
+        { value: 'subdoc.secret', maskedValue: (s) => '@'.repeat(s.length) },
+      ],
+      singleCollection: true,
+      saveWholeDoc: true,
+      maxBatchLog: 5,
+    });
+
+    Order = mongoose.model('Order', orderSchema);
+    LogHistory = getLogHistoryModel('Order', true);
+  });
+
+  afterEach(async () => {
+    await Order.deleteMany({});
+    await LogHistory.deleteMany({});
+  });
+
+  const wait = () => new Promise((resolve) => setTimeout(resolve, 100));
+
+  it('logs masked value via create', async () => {
+    const order = await Order.create({ name: 'John Doe' });
+    await wait();
+
+    const logs = await LogHistory.find({ model_id: order._id, change_type: 'create' }).lean();
+    expect(logs.length).toBe(1);
+    const log = logs[0];
+    expect(log.model).toBe('Order');
+    expect(log.logs.length).toBe(0);
+    expect(log.original_doc).toBe(null);
+    expect(log.updated_doc).toBeDefined();
+    expect(log.updated_doc.name).toBe('***');
+  });
+
+  it('logs nested masked value via create', async () => {
+    const order = await Order.create({ subdoc: { secret: 'secret', plain: 'plain' } });
+    await wait();
+
+    const logs = await LogHistory.find({ model_id: order._id, change_type: 'create' }).lean();
+    expect(logs.length).toBe(1);
+    const log = logs[0];
+    expect(log.model).toBe('Order');
+    expect(log.logs.length).toBe(0);
+    expect(log.original_doc).toBe(null);
+    expect(log.updated_doc).toBeDefined();
+    expect(log.updated_doc.subdoc.secret).toBe('@@@@@@');
+    expect(log.updated_doc.subdoc.plain).toBe('plain');
+  });
+
+  it('logs masked value via updateOne', async () => {
+    const order = await Order.create({ name: 'John Doe' });
+    await Order.updateOne({ _id: order._id }, { $set: { name: 'Jane Doe' } });
+    await wait();
+
+    const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
+    expect(logs.length).toBe(1);
+    const log = logs[0];
+    expect(log.model).toBe('Order');
+    expect(log.logs.length).toBe(1);
+    expect(log.logs[0].from_value).toBe('***');
+    expect(log.logs[0].to_value).toBe('***');
+    expect(log.original_doc).toBeDefined();
+    expect(log.original_doc.name).toBe('***');
+    expect(log.updated_doc).toBeDefined();
+    expect(log.updated_doc.name).toBe('***');
+  });
+
+  it('logs nested masked value via updateOne', async () => {
+    const order = await Order.create({ subdoc: { secret: 'secret', plain: 'plain' } });
+    await Order.updateOne({ _id: order._id }, { $set: { subdoc: { secret: 'new_secret', plain: 'new_plain' } } });
+    await wait();
+
+    const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
+    expect(logs.length).toBe(1);
+    const log = logs[0];
+    expect(log.model).toBe('Order');
+    expect(log.logs.length).toBe(1);
+    expect(log.logs[0].from_value).toBe('@@@@@@');
+    expect(log.logs[0].to_value).toBe('@@@@@@@@@@');
+    expect(log.original_doc).toBeDefined();
+    expect(log.original_doc.subdoc.secret).toBe('@@@@@@');
+    expect(log.updated_doc).toBeDefined();
+    expect(log.updated_doc.subdoc.secret).toBe('@@@@@@@@@@');
+  });
+
+  it('logs masked value via findOneAndUpdate', async () => {
+    const order = await Order.create({ name: 'John Doe' });
+    await Order.findOneAndUpdate({ _id: order._id }, { $set: { name: 'Jane Doe' } });
+    await wait();
+
+    const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
+    expect(logs.length).toBe(1);
+    const log = logs[0];
+    expect(log.model).toBe('Order');
+    expect(log.logs.length).toBe(1);
+    expect(log.logs[0].from_value).toBe('***');
+    expect(log.logs[0].to_value).toBe('***');
+    expect(log.original_doc).toBeDefined();
+    expect(log.original_doc.name).toBe('***');
+    expect(log.updated_doc).toBeDefined();
+    expect(log.updated_doc.name).toBe('***');
+  });
+
+  it('logs nested masked value via findOneAndUpdate', async () => {
+    const order = await Order.create({ subdoc: { secret: 'secret', plain: 'plain' } });
+    await Order.findOneAndUpdate(
+      { _id: order._id },
+      { $set: { subdoc: { secret: 'new_secret', plain: 'new_plain' } } }
+    );
+    await wait();
+
+    const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
+    expect(logs.length).toBe(1);
+    const log = logs[0];
+    expect(log.model).toBe('Order');
+    expect(log.logs.length).toBe(1);
+    expect(log.logs[0].from_value).toBe('@@@@@@');
+    expect(log.logs[0].to_value).toBe('@@@@@@@@@@');
+    expect(log.original_doc).toBeDefined();
+    expect(log.original_doc.subdoc.secret).toBe('@@@@@@');
+    expect(log.updated_doc).toBeDefined();
+    expect(log.updated_doc.subdoc.secret).toBe('@@@@@@@@@@');
+  });
+
+  it('logs masked value via updateMany', async () => {
+    const orders = await Order.insertMany([{ name: 'John Doe' }, { name: 'John Doe' }]);
+    await LogHistory.deleteMany({});
+    await Order.updateMany({}, { $set: { name: 'Jane Doe' } });
+    await wait();
+
+    for (const order of orders) {
+      const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
+      expect(logs.length).toBe(1);
+      const log = logs[0];
+      expect(log.model).toBe('Order');
+      expect(log.logs.length).toBe(1);
+      expect(log.logs[0].from_value).toBe('***');
+      expect(log.logs[0].to_value).toBe('***');
+      expect(log.original_doc).toBeDefined();
+      expect(log.original_doc.name).toBe('***');
+      expect(log.updated_doc).toBeDefined();
+      expect(log.updated_doc.name).toBe('***');
+    }
+  });
+
+  it('logs nested masked value via updateMany', async () => {
+    const orders = await Order.insertMany([
+      { subdoc: { secret: 'secret', plain: 'plain' } },
+      { subdoc: { secret: 'secret', plain: 'plain' } },
+    ]);
+    await LogHistory.deleteMany({});
+    await Order.updateMany({}, { $set: { subdoc: { secret: 'new_secret', plain: 'new_plain' } } });
+    await wait();
+
+    for (const order of orders) {
+      const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
+      expect(logs.length).toBe(1);
+      const log = logs[0];
+      expect(log.model).toBe('Order');
+      expect(log.logs.length).toBe(1);
+      expect(log.logs[0].from_value).toBe('@@@@@@');
+      expect(log.logs[0].to_value).toBe('@@@@@@@@@@');
+      expect(log.original_doc).toBeDefined();
+      expect(log.original_doc.subdoc.secret).toBe('@@@@@@');
+      expect(log.updated_doc).toBeDefined();
+      expect(log.updated_doc.subdoc.secret).toBe('@@@@@@@@@@');
+    }
+  });
+
+  it('logs masked value when field is set via save', async () => {
+    const order = await Order.create({ name: 'John Doe' });
+    order.name = 'Judy Doe';
+    await order.save();
+    await wait();
+
+    const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
+    expect(logs.length).toBe(1);
+    const log = logs[0];
+    expect(log.model).toBe('Order');
+    expect(log.logs.length).toBe(1);
+    expect(log.logs[0].from_value).toBe('***');
+    expect(log.logs[0].to_value).toBe('***');
+    expect(log.original_doc).toBeDefined();
+    expect(log.original_doc.name).toBe('***');
+    expect(log.updated_doc).toBeDefined();
+    expect(log.updated_doc.name).toBe('***');
+  });
+
+  it('logs nested masked value when field is set via save', async () => {
+    const order = await Order.create({ subdoc: { secret: 'secret', plain: 'plain' } });
+    order.subdoc.secret = 'new_secret';
+    order.subdoc.plain = 'new_plain';
+    await order.save();
+    await wait();
+
+    const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
+    expect(logs.length).toBe(1);
+    const log = logs[0];
+    expect(log.model).toBe('Order');
+    expect(log.logs.length).toBe(1);
+    expect(log.logs[0].from_value).toBe('@@@@@@');
+    expect(log.logs[0].to_value).toBe('@@@@@@@@@@');
+    expect(log.original_doc).toBeDefined();
+    expect(log.original_doc.subdoc.secret).toBe('@@@@@@');
+    expect(log.updated_doc).toBeDefined();
+    expect(log.updated_doc.subdoc.secret).toBe('@@@@@@@@@@');
+  });
+
+  it('logs masked value when field is set via replaceOne', async () => {
+    const order = await Order.create({ name: 'John Doe' });
+    await Order.replaceOne({ _id: order._id }, { name: 'Jane Doe' });
+    await wait();
+
+    const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
+    expect(logs.length).toBe(1);
+    const log = logs[0];
+    expect(log.model).toBe('Order');
+    expect(log.logs.length).toBe(1);
+    expect(log.logs[0].from_value).toBe('***');
+    expect(log.logs[0].to_value).toBe('***');
+    expect(log.original_doc).toBeDefined();
+    expect(log.original_doc.name).toBe('***');
+    expect(log.updated_doc).toBeDefined();
+    expect(log.updated_doc.name).toBe('***');
+  });
+
+  it('logs nested masked value when field is set via replaceOne', async () => {
+    const order = await Order.create({ subdoc: { secret: 'secret', plain: 'plain' } });
+    await Order.replaceOne({ _id: order._id }, { subdoc: { secret: 'new_secret', plain: 'new_plain' } });
+    await wait();
+
+    const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
+    expect(logs.length).toBe(1);
+    const log = logs[0];
+    expect(log.model).toBe('Order');
+    expect(log.logs.length).toBe(1);
+    expect(log.logs[0].from_value).toBe('@@@@@@');
+    expect(log.logs[0].to_value).toBe('@@@@@@@@@@');
+    expect(log.original_doc).toBeDefined();
+    expect(log.original_doc.subdoc.secret).toBe('@@@@@@');
+    expect(log.updated_doc).toBeDefined();
+    expect(log.updated_doc.subdoc.secret).toBe('@@@@@@@@@@');
+  });
+
+  it('logs masked value when field is set via findOneAndReplace', async () => {
+    const order = await Order.create({ name: 'John Doe' });
+    await Order.findOneAndReplace({ _id: order._id }, { name: 'Jane Doe' });
+    await wait();
+
+    const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
+    expect(logs.length).toBe(1);
+    const log = logs[0];
+    expect(log.model).toBe('Order');
+    expect(log.logs.length).toBe(1);
+    expect(log.logs[0].from_value).toBe('***');
+    expect(log.logs[0].to_value).toBe('***');
+    expect(log.original_doc).toBeDefined();
+    expect(log.original_doc.name).toBe('***');
+    expect(log.updated_doc).toBeDefined();
+    expect(log.updated_doc.name).toBe('***');
+  });
+
+  it('logs nested masked value when field is set via findOneAndReplace', async () => {
+    const order = await Order.create({ subdoc: { secret: 'secret', plain: 'plain' } });
+    await Order.findOneAndReplace({ _id: order._id }, { subdoc: { secret: 'new_secret', plain: 'new_plain' } });
+    await wait();
+
+    const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
+    expect(logs.length).toBe(1);
+    const log = logs[0];
+    expect(log.model).toBe('Order');
+    expect(log.logs.length).toBe(1);
+    expect(log.logs[0].from_value).toBe('@@@@@@');
+    expect(log.logs[0].to_value).toBe('@@@@@@@@@@');
+    expect(log.original_doc).toBeDefined();
+    expect(log.original_doc.subdoc.secret).toBe('@@@@@@');
+    expect(log.updated_doc).toBeDefined();
+    expect(log.updated_doc.subdoc.secret).toBe('@@@@@@@@@@');
+  });
+
+  it('logs masked values for multiple docs in updateMany (batch limit)', async () => {
+    await Order.insertMany([
+      { name: 'John Doe' },
+      { name: 'John Doe' },
+      { name: 'John Doe' },
+      { name: 'John Doe' },
+      { name: 'John Doe' },
+      { name: 'John Doe' },
+    ]);
+    await LogHistory.deleteMany({});
+    await Order.updateMany({}, { $set: { name: 'Jane Doe' } });
+    await wait();
+
+    const logs = await LogHistory.find({ change_type: 'update' }).lean();
+    expect(logs.length).toBe(5);
+
+    for (const log of logs) {
+      expect(log.model).toBe('Order');
+      expect(log.logs.length).toBe(1);
+      expect(log.logs[0].from_value).toBe('***');
+      expect(log.logs[0].to_value).toBe('***');
+      expect(log.original_doc).toBeDefined();
+      expect(log.original_doc.name).toBe('***');
+      expect(log.updated_doc).toBeDefined();
+      expect(log.updated_doc.name).toBe('***');
+    }
+  });
+
+  it('logs nested masked values for multiple docs in updateMany (batch limit)', async () => {
+    await Order.insertMany([
+      { subdoc: { secret: 'secret', plain: 'plain' } },
+      { subdoc: { secret: 'secret', plain: 'plain' } },
+      { subdoc: { secret: 'secret', plain: 'plain' } },
+      { subdoc: { secret: 'secret', plain: 'plain' } },
+      { subdoc: { secret: 'secret', plain: 'plain' } },
+      { subdoc: { secret: 'secret', plain: 'plain' } },
+    ]);
+    await LogHistory.deleteMany({});
+    await Order.updateMany({}, { $set: { subdoc: { secret: 'new_secret', plain: 'new_plain' } } });
+    await wait();
+
+    const logs = await LogHistory.find({ change_type: 'update' }).lean();
+    expect(logs.length).toBe(5);
+
+    for (const log of logs) {
+      expect(log.model).toBe('Order');
+      expect(log.logs.length).toBe(1);
+      expect(log.logs[0].from_value).toBe('@@@@@@');
+      expect(log.logs[0].to_value).toBe('@@@@@@@@@@');
+      expect(log.original_doc).toBeDefined();
+      expect(log.original_doc.subdoc.secret).toBe('@@@@@@');
+      expect(log.updated_doc).toBeDefined();
+      expect(log.updated_doc.subdoc.secret).toBe('@@@@@@@@@@');
+    }
+  });
+});

--- a/test/integration/optionValidation.integration.test.js
+++ b/test/integration/optionValidation.integration.test.js
@@ -159,4 +159,28 @@ describe('mongoose-log-history plugin - Option Validation', () => {
       });
     }).toThrow(/modelKeyId/);
   });
+
+  it('throws if maskedValue config is invalid', () => {
+    const schema = new mongoose.Schema({ status: String });
+    expect(() => {
+      schema.plugin(changeLoggingPlugin, {
+        modelName: 'Order',
+        trackedFields: [{ value: 'status', maskedValue: true }],
+      });
+    }).toThrow(/masked/);
+
+    expect(() => {
+      schema.plugin(changeLoggingPlugin, {
+        modelName: 'Order',
+        trackedFields: [{ value: 'status', maskedValue: new Date() }],
+      });
+    }).toThrow(/masked/);
+
+    expect(() => {
+      schema.plugin(changeLoggingPlugin, {
+        modelName: 'Order',
+        trackedFields: [{ value: 'status', maskedValue: { invalid: true } }],
+      });
+    }).toThrow(/masked/);
+  });
 });


### PR DESCRIPTION
Resolves https://github.com/granitebps/mongoose-log-history/issues/14

Adds support for masking values in the logs using a string value or a function.

TODO: update readme

**Example**

```js
    const orderSchema = new mongoose.Schema({
      name: String,
      tags: [String],
      subdoc: {
        secret: String,
        plain: String,
      },
    });

    orderSchema.plugin(changeLoggingPlugin, {
      modelName: 'Order',
      trackedFields: [
        { value: 'name', maskedValue: '***' },
        { value: 'subdoc.secret', maskedValue: (s) => '@'.repeat(s.length) },
      ],
      singleCollection: true,
      saveWholeDoc: true,
      maxBatchLog: 5,
    });
```

Logs for `name` will be masked with `***` while logs for `subdoc.secret` will be masked with a string of `@` based on the the length of the secret.