### PR TITLE
PERF: remove some overhead for each log save

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -154,6 +154,7 @@ export class ChangeLogPlugin {
   public readonly modelName: string;
   public readonly modelKeyId: string;
   public readonly trackedFields: TrackedField[];
+  public readonly selectTrackedFields: string;
   public readonly contextFields: string[];
   public readonly softDelete: { field: string; value: unknown } | null;
   public readonly singleCollection: boolean;
@@ -179,6 +180,7 @@ export class ChangeLogPlugin {
     this.logger = options.logger ?? console;
     this.userField = options.userField ?? 'created_by';
     this.compressDocs = options.compressDocs === true;
+    this.selectTrackedFields = [...new Set(this.trackedFields.map((f) => f.value.split('.')[0]))].join(' ');
   }
 
   /**
@@ -673,9 +675,7 @@ export class ChangeLogPlugin {
         const options = query.getOptions() ?? {};
         const context = (options as { context?: Record<string, unknown> }).context ?? {};
 
-        const trackedPaths = [...new Set(self.trackedFields.map((f) => f.value.split('.')[0]))];
-
-        const originalDoc = (await model.findOne(filter).select(trackedPaths.join(' ')).lean()) as Record<
+        const originalDoc = (await model.findOne(filter).select(self.selectTrackedFields).lean()) as Record<
           string,
           unknown
         > | null;
@@ -767,7 +767,6 @@ export class ChangeLogPlugin {
           userField: self.userField,
         });
 
-        const trackedPaths = [...new Set(self.trackedFields.map((f) => f.value.split('.')[0]))];
         modelId = getValueByPath(doc.toObject(), self.modelKeyId) as string | number | Types.ObjectId;
 
         if (isNew) {
@@ -780,7 +779,7 @@ export class ChangeLogPlugin {
         } else {
           const originalDoc = (await (doc.constructor as Model<Document>)
             .findById(doc._id)
-            .select(trackedPaths.join(' '))
+            .select(self.selectTrackedFields)
             .lean()) as Record<string, unknown> | null;
 
           if (!originalDoc) {
@@ -940,8 +939,7 @@ export class ChangeLogPlugin {
         const options = query.getOptions() ?? {};
         const context = (options as { context?: Record<string, unknown> }).context ?? {};
 
-        const trackedPaths = [...new Set(self.trackedFields.map((f) => f.value.split('.')[0]))];
-        const originalDocs = (await model.find(filter).select(trackedPaths.join(' ')).lean()) as Record<
+        const originalDocs = (await model.find(filter).select(self.selectTrackedFields).lean()) as Record<
           string,
           unknown
         >[];


### PR DESCRIPTION
Many types of log save hooks map the tracked fields to return a list of fields to select via mongoose projection.

This change removes some copy/paste code and also computes the list once to reduce some overhead on each save.
