### PR TITLE
PERF: remove wait calls

### DIFF
--- a/test/integration/array.integration.test.js
+++ b/test/integration/array.integration.test.js
@@ -42,15 +42,12 @@ describe('mongoose-log-history plugin - Array Field Tracking', () => {
     await LogHistory.deleteMany({});
   });
 
-  const wait = () => new Promise((resolve) => setTimeout(resolve, 100));
-
   describe('Simple array (arrayType: simple)', () => {
     it('logs add and remove in simple array', async () => {
       const order = await Order.create({ tags: ['a', 'b'] });
       await LogHistory.deleteMany({});
       order.tags = ['b', 'c'];
       await order.save();
-      await wait();
 
       const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
       expect(logs.length).toBe(1);
@@ -66,7 +63,6 @@ describe('mongoose-log-history plugin - Array Field Tracking', () => {
       await LogHistory.deleteMany({});
       order.tags = ['a', 'b'];
       await order.save();
-      await wait();
 
       const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
       expect(logs[0].logs.some((l) => l.change_type === 'add' && l.to_value === 'b')).toBe(true);
@@ -77,7 +73,6 @@ describe('mongoose-log-history plugin - Array Field Tracking', () => {
       await LogHistory.deleteMany({});
       order.tags = ['a'];
       await order.save();
-      await wait();
 
       const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
       expect(logs[0].logs.some((l) => l.change_type === 'remove' && l.from_value === 'b')).toBe(true);
@@ -88,7 +83,6 @@ describe('mongoose-log-history plugin - Array Field Tracking', () => {
       await LogHistory.deleteMany({});
       order.tags = ['a', 'b'];
       await order.save();
-      await wait();
 
       const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
       expect(logs.length).toBe(0);
@@ -99,7 +93,6 @@ describe('mongoose-log-history plugin - Array Field Tracking', () => {
       await LogHistory.deleteMany({});
       order.tags = null;
       await order.save();
-      await wait();
 
       const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
       expect(logs.length).toBe(0);
@@ -120,7 +113,6 @@ describe('mongoose-log-history plugin - Array Field Tracking', () => {
         { sku: 'C', qty: 4, price: 40 },
       ];
       await order.save();
-      await wait();
 
       const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
       expect(logs.length).toBe(1);
@@ -141,7 +133,6 @@ describe('mongoose-log-history plugin - Array Field Tracking', () => {
         { sku: 'B', qty: 2, price: 20 },
       ];
       await order.save();
-      await wait();
 
       const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
       expect(logs[0].logs.some((l) => l.change_type === 'add' && l.field_name === 'items')).toBe(true);
@@ -157,7 +148,6 @@ describe('mongoose-log-history plugin - Array Field Tracking', () => {
       await LogHistory.deleteMany({});
       order.items = [{ sku: 'A', qty: 1, price: 10 }];
       await order.save();
-      await wait();
 
       const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
       expect(logs[0].logs.some((l) => l.change_type === 'remove' && l.field_name === 'items')).toBe(true);
@@ -170,7 +160,6 @@ describe('mongoose-log-history plugin - Array Field Tracking', () => {
       await LogHistory.deleteMany({});
       order.items = [{ sku: 'A', qty: 2, price: 15 }];
       await order.save();
-      await wait();
 
       const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
       expect(logs[0].logs.some((l) => l.field_name === 'items.qty' && l.change_type === 'edit')).toBe(true);
@@ -184,7 +173,6 @@ describe('mongoose-log-history plugin - Array Field Tracking', () => {
       await LogHistory.deleteMany({});
       order.items = [{ sku: 'A', qty: 1, price: 10 }];
       await order.save();
-      await wait();
 
       const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
       expect(logs.length).toBe(0);
@@ -195,7 +183,6 @@ describe('mongoose-log-history plugin - Array Field Tracking', () => {
       await LogHistory.deleteMany({});
       order.items = null;
       await order.save();
-      await wait();
 
       const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
       expect(logs.length).toBe(0);

--- a/test/integration/batchLimits.integration.test.js
+++ b/test/integration/batchLimits.integration.test.js
@@ -34,8 +34,6 @@ describe('mongoose-log-history plugin - Batch Size and Max Batch Log', () => {
     warnSpy.mockRestore();
   });
 
-  const wait = () => new Promise((resolve) => setTimeout(resolve, 100));
-
   it('respects maxBatchLog limit in updateMany', async () => {
     await Order.insertMany([
       { status: 'a' },
@@ -47,7 +45,6 @@ describe('mongoose-log-history plugin - Batch Size and Max Batch Log', () => {
     ]);
     await LogHistory.deleteMany({});
     await Order.updateMany({}, { $set: { status: 'z' } });
-    await wait();
 
     const logs = await LogHistory.find({ change_type: 'update' }).lean();
     expect(logs.length).toBe(5);
@@ -61,7 +58,6 @@ describe('mongoose-log-history plugin - Batch Size and Max Batch Log', () => {
     await Order.insertMany([{ status: 'a' }, { status: 'a' }, { status: 'a' }, { status: 'a' }]);
     await LogHistory.deleteMany({});
     await Order.updateMany({}, { $set: { status: 'z' } });
-    await wait();
 
     const logs = await LogHistory.find({ change_type: 'update' }).lean();
     expect(logs.length).toBe(4);
@@ -78,7 +74,6 @@ describe('mongoose-log-history plugin - Batch Size and Max Batch Log', () => {
     ]);
     await LogHistory.deleteMany({});
     await Order.deleteMany({});
-    await wait();
 
     const logs = await LogHistory.find({ change_type: 'delete' }).lean();
     expect(logs.length).toBe(5);
@@ -91,7 +86,6 @@ describe('mongoose-log-history plugin - Batch Size and Max Batch Log', () => {
       docs.push({ status: 'a' });
     }
     await Order.insertMany(docs);
-    await wait();
 
     const logs = await LogHistory.find({ change_type: 'create' }).lean();
 

--- a/test/integration/compression.integration.test.js
+++ b/test/integration/compression.integration.test.js
@@ -30,11 +30,8 @@ describe('mongoose-log-history plugin - Compression', () => {
     await LogHistory.deleteMany({});
   });
 
-  const wait = () => new Promise((resolve) => setTimeout(resolve, 100));
-
   it('stores updated_doc as Binary (compressed) and original_doc as null on create', async () => {
     const order = await Order.create({ status: 'pending', data: 'x'.repeat(1000) });
-    await wait();
 
     const log = await LogHistory.findOne({ model_id: order._id, change_type: 'create' });
     expect(log.original_doc).toBeNull();
@@ -43,7 +40,6 @@ describe('mongoose-log-history plugin - Compression', () => {
 
   it('automatically decompresses docs in getHistoriesById', async () => {
     const order = await Order.create({ status: 'pending', data: 'foo' });
-    await wait();
 
     const logs = await Order.getHistoriesById(order._id);
     expect(logs.length).toBe(1);
@@ -55,7 +51,6 @@ describe('mongoose-log-history plugin - Compression', () => {
 
   it('manual decompressObject works on Binary', async () => {
     const order = await Order.create({ status: 'pending', data: 'bar' });
-    await wait();
 
     const log = await LogHistory.findOne({ model_id: order._id, change_type: 'create' });
     const buf = log.updated_doc._bsontype === 'Binary' ? log.updated_doc.buffer : log.updated_doc;
@@ -95,7 +90,6 @@ describe('mongoose-log-history plugin - Compression', () => {
     order.status = 'done';
     order.data = 'bar';
     await order.save();
-    await wait();
 
     const log = await LogHistory.findOne({ model_id: order._id, change_type: 'update' });
     expect(log.original_doc).toBeInstanceOf(Binary);

--- a/test/integration/contextFields.integration.test.js
+++ b/test/integration/contextFields.integration.test.js
@@ -55,14 +55,11 @@ describe('mongoose-log-history plugin - Context Fields', () => {
     await LogHistory.deleteMany({});
   });
 
-  const wait = () => new Promise((resolve) => setTimeout(resolve, 100));
-
   it('includes global contextFields in log', async () => {
     const order = await Order.create({
       status: 'pending',
       user: { name: 'Alice', role: 'admin' },
     });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'create' }).lean();
     expect(logs.length).toBe(1);
@@ -79,7 +76,6 @@ describe('mongoose-log-history plugin - Context Fields', () => {
     await LogHistory.deleteMany({});
     order.status = 'done';
     await order.save();
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
     expect(logs.length).toBe(1);
@@ -97,7 +93,6 @@ describe('mongoose-log-history plugin - Context Fields', () => {
     await LogHistory.deleteMany({});
     order.items = [{ sku: 'A', qty: 2, meta: { color: 'blue' } }];
     await order.save();
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
     expect(logs.length).toBe(1);
@@ -113,7 +108,6 @@ describe('mongoose-log-history plugin - Context Fields', () => {
     const order = await Order.create({
       status: 'pending',
     });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'create' }).lean();
     expect(logs.length).toBe(1);
@@ -126,7 +120,6 @@ describe('mongoose-log-history plugin - Context Fields', () => {
       status: 'pending',
       user: { name: null, role: undefined },
     });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'create' }).lean();
     expect(logs.length).toBe(1);
@@ -142,7 +135,6 @@ describe('mongoose-log-history plugin - Context Fields', () => {
     await LogHistory.deleteMany({});
     order.items = [{ sku: 'B', qty: 2 }];
     await order.save();
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
     expect(logs.length).toBe(1);

--- a/test/integration/create.integration.test.js
+++ b/test/integration/create.integration.test.js
@@ -39,12 +39,9 @@ describe('mongoose-log-history plugin - Create Operation (all hooks and edge cas
     await LogHistory.deleteMany({});
   });
 
-  const wait = () => new Promise((resolve) => setTimeout(resolve, 100));
-
   it('logs create via save (document hook)', async () => {
     const order = new Order({ status: 'pending' });
     await order.save();
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id }).lean();
     expect(logs.length).toBe(1);
@@ -57,7 +54,6 @@ describe('mongoose-log-history plugin - Create Operation (all hooks and edge cas
 
   it('logs create via insertMany (plain object)', async () => {
     const [order] = await Order.insertMany([{ status: 'pending' }]);
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id }).lean();
     expect(logs.length).toBe(1);
@@ -70,7 +66,6 @@ describe('mongoose-log-history plugin - Create Operation (all hooks and edge cas
   it('logs create via insertMany (Mongoose document)', async () => {
     const doc = new Order({ status: 'pending' });
     const [order] = await Order.insertMany([doc]);
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id }).lean();
     expect(logs.length).toBe(1);
@@ -82,7 +77,6 @@ describe('mongoose-log-history plugin - Create Operation (all hooks and edge cas
   it('logs create with explicit _id', async () => {
     const customId = new mongoose.Types.ObjectId();
     await Order.insertMany([{ _id: customId, status: 'pending' }]);
-    await wait();
 
     const logs = await LogHistory.find({ model_id: customId }).lean();
     expect(logs.length).toBe(1);
@@ -102,7 +96,6 @@ describe('mongoose-log-history plugin - Create Operation (all hooks and edge cas
 
     const doc = new NoTrack({ foo: 'bar' });
     await doc.save();
-    await wait();
 
     const logs = await LogHistoryNoTrack.find({ model_id: doc._id }).lean();
 
@@ -113,7 +106,6 @@ describe('mongoose-log-history plugin - Create Operation (all hooks and edge cas
   it('handles missing/invalid input gracefully', async () => {
     const order = new Order({});
     await expect(order.save()).resolves.toBeDefined();
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id }).lean();
     expect(logs.length).toBe(1);
@@ -122,7 +114,6 @@ describe('mongoose-log-history plugin - Create Operation (all hooks and edge cas
 
   it('logs create with extra/unexpected fields', async () => {
     const [order] = await Order.insertMany([{ status: 'pending', foo: 'bar', bar: 123 }]);
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id }).lean();
     expect(logs.length).toBe(1);
@@ -131,7 +122,6 @@ describe('mongoose-log-history plugin - Create Operation (all hooks and edge cas
 
   it('logs create with null/undefined values', async () => {
     const [order] = await Order.insertMany([{ status: null }]);
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id }).lean();
     expect(logs.length).toBe(1);
@@ -141,7 +131,6 @@ describe('mongoose-log-history plugin - Create Operation (all hooks and edge cas
   it('logs create with large document', async () => {
     const bigString = 'x'.repeat(10000);
     const [order] = await Order.insertMany([{ status: bigString }]);
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id }).lean();
     expect(logs.length).toBe(1);

--- a/test/integration/delete.integration.test.js
+++ b/test/integration/delete.integration.test.js
@@ -39,12 +39,9 @@ describe('mongoose-log-history plugin - Delete Operation (all hooks and edge cas
     await LogHistory.deleteMany({});
   });
 
-  const wait = () => new Promise((resolve) => setTimeout(resolve, 100));
-
   it('logs delete via deleteOne (query)', async () => {
     const order = await Order.create({ status: 'pending' });
     await Order.deleteOne({ _id: order._id });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'delete' }).lean();
     expect(logs.length).toBe(1);
@@ -56,7 +53,6 @@ describe('mongoose-log-history plugin - Delete Operation (all hooks and edge cas
     const order1 = await Order.create({ status: 'pending' });
     const order2 = await Order.create({ status: 'pending' });
     await Order.deleteMany({ status: 'pending' });
-    await wait();
 
     const logs1 = await LogHistory.find({ model_id: order1._id, change_type: 'delete' }).lean();
     const logs2 = await LogHistory.find({ model_id: order2._id, change_type: 'delete' }).lean();
@@ -71,7 +67,6 @@ describe('mongoose-log-history plugin - Delete Operation (all hooks and edge cas
   it('logs delete via findOneAndDelete', async () => {
     const order = await Order.create({ status: 'pending' });
     await Order.findOneAndDelete({ _id: order._id });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'delete' }).lean();
     expect(logs.length).toBe(1);
@@ -82,7 +77,6 @@ describe('mongoose-log-history plugin - Delete Operation (all hooks and edge cas
   it('logs delete via findByIdAndDelete', async () => {
     const order = await Order.create({ status: 'pending' });
     await Order.findByIdAndDelete(order._id);
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'delete' }).lean();
     expect(logs.length).toBe(1);
@@ -93,7 +87,6 @@ describe('mongoose-log-history plugin - Delete Operation (all hooks and edge cas
   it('logs delete via deleteOne (doc instance)', async () => {
     const order = await Order.create({ status: 'pending' });
     await order.deleteOne();
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'delete' }).lean();
     expect(logs.length).toBe(1);
@@ -104,7 +97,6 @@ describe('mongoose-log-history plugin - Delete Operation (all hooks and edge cas
   it('does not log delete for non-existent document', async () => {
     const fakeId = new mongoose.Types.ObjectId();
     await Order.deleteOne({ _id: fakeId });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: fakeId, change_type: 'delete' }).lean();
     expect(logs.length).toBe(0);
@@ -122,7 +114,6 @@ describe('mongoose-log-history plugin - Delete Operation (all hooks and edge cas
 
     const doc = await NoTrackDelete.create({ foo: 'bar' });
     await doc.deleteOne();
-    await wait();
 
     const logs = await LogHistoryNoTrack.find({ model_id: doc._id, change_type: 'delete' }).lean();
 
@@ -132,7 +123,6 @@ describe('mongoose-log-history plugin - Delete Operation (all hooks and edge cas
 
   it('handles delete with missing/invalid input gracefully', async () => {
     await Order.deleteMany({});
-    await wait();
 
     const logs = await LogHistory.find({ change_type: 'delete' }).lean();
 
@@ -143,7 +133,6 @@ describe('mongoose-log-history plugin - Delete Operation (all hooks and edge cas
     const bigString = 'x'.repeat(10000);
     const order = await Order.create({ status: bigString });
     await order.deleteOne();
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'delete' }).lean();
     expect(logs.length).toBe(1);

--- a/test/integration/errorHandling.integration.test.js
+++ b/test/integration/errorHandling.integration.test.js
@@ -37,8 +37,6 @@ describe('mongoose-log-history plugin - Error Handling', () => {
     }
   });
 
-  const wait = () => new Promise((resolve) => setTimeout(resolve, 100));
-
   it('does not block document save if logging fails', async () => {
     const origCreate = LogHistory.create;
     LogHistory.create = () => {
@@ -57,7 +55,6 @@ describe('mongoose-log-history plugin - Error Handling', () => {
 
   it('does not block update if logging fails', async () => {
     const order = await Order.create({ status: 'pending' });
-    await wait();
 
     const origCreate = LogHistory.create;
     LogHistory.create = () => {
@@ -72,7 +69,6 @@ describe('mongoose-log-history plugin - Error Handling', () => {
 
   it('does not block delete if logging fails', async () => {
     const order = await Order.create({ status: 'pending' });
-    await wait();
 
     const origBulkWrite = LogHistory.bulkWrite;
     LogHistory.bulkWrite = () => {
@@ -87,7 +83,6 @@ describe('mongoose-log-history plugin - Error Handling', () => {
 
   it('does not block batch operations if logging fails', async () => {
     await Order.insertMany([{ status: 'a' }, { status: 'b' }]);
-    await wait();
 
     const origBulkWrite = LogHistory.bulkWrite;
     LogHistory.bulkWrite = () => {

--- a/test/integration/modelIdTypes.integration.test.js
+++ b/test/integration/modelIdTypes.integration.test.js
@@ -3,8 +3,6 @@ const mongoose = require('mongoose');
 const { changeLoggingPlugin, getLogHistoryModel } = require('../../dist');
 
 describe('mongoose-log-history plugin - Model ID Types (string, number, ObjectId)', () => {
-  const wait = () => new Promise((resolve) => setTimeout(resolve, 100));
-
   afterEach(async () => {
     // Clean up all models created during tests
     const modelNames = Object.keys(mongoose.connection.models);
@@ -36,7 +34,6 @@ describe('mongoose-log-history plugin - Model ID Types (string, number, ObjectId
       // Create document with string ID
       const stringId = 'user-12345';
       const doc = await Model.create({ _id: stringId, status: 'pending', name: 'Test' });
-      await wait();
 
       // Verify create log
       let logs = await LogHistory.find({ model_id: stringId }).lean();
@@ -47,7 +44,6 @@ describe('mongoose-log-history plugin - Model ID Types (string, number, ObjectId
       // Update document
       doc.status = 'completed';
       await doc.save();
-      await wait();
 
       // Verify update log
       logs = await LogHistory.find({ model_id: stringId }).lean();
@@ -83,7 +79,6 @@ describe('mongoose-log-history plugin - Model ID Types (string, number, ObjectId
         { _id: 'doc-003', status: 'pending' },
       ];
       await Model.insertMany(docs);
-      await wait();
 
       // Verify all logs created
       const logs = await LogHistory.find({}).lean();
@@ -117,7 +112,6 @@ describe('mongoose-log-history plugin - Model ID Types (string, number, ObjectId
 
       // Update many
       await Model.updateMany({ category: 'A' }, { $set: { status: 'approved' } });
-      await wait();
 
       const logs = await LogHistory.find({ change_type: 'update' }).lean();
       expect(logs.length).toBe(2);
@@ -145,7 +139,6 @@ describe('mongoose-log-history plugin - Model ID Types (string, number, ObjectId
       // Create document with number ID
       const numberId = 12345;
       const doc = await Model.create({ _id: numberId, status: 'pending', name: 'Test' });
-      await wait();
 
       // Verify create log
       let logs = await LogHistory.find({ model_id: numberId }).lean();
@@ -156,7 +149,6 @@ describe('mongoose-log-history plugin - Model ID Types (string, number, ObjectId
       // Update document
       doc.status = 'completed';
       await doc.save();
-      await wait();
 
       // Verify update log
       logs = await LogHistory.find({ model_id: numberId }).lean();
@@ -192,7 +184,6 @@ describe('mongoose-log-history plugin - Model ID Types (string, number, ObjectId
         { _id: 1003, status: 'pending' },
       ];
       await Model.insertMany(docs);
-      await wait();
 
       // Verify all logs created
       const logs = await LogHistory.find({}).lean();
@@ -225,7 +216,6 @@ describe('mongoose-log-history plugin - Model ID Types (string, number, ObjectId
 
       // Delete docs
       await Model.deleteMany({ _id: { $in: [2001, 2002] } });
-      await wait();
 
       const logs = await LogHistory.find({ change_type: 'delete' }).lean();
       expect(logs.length).toBe(2);
@@ -252,7 +242,6 @@ describe('mongoose-log-history plugin - Model ID Types (string, number, ObjectId
 
       // Create document with default ObjectId
       const doc = await Model.create({ status: 'pending', name: 'Test' });
-      await wait();
 
       const objectId = doc._id;
 
@@ -265,7 +254,6 @@ describe('mongoose-log-history plugin - Model ID Types (string, number, ObjectId
       // Update document
       doc.status = 'completed';
       await doc.save();
-      await wait();
 
       // Verify update log
       logs = await LogHistory.find({ model_id: objectId }).lean();
@@ -294,7 +282,6 @@ describe('mongoose-log-history plugin - Model ID Types (string, number, ObjectId
       // Create with explicit ObjectId
       const customObjectId = new mongoose.Types.ObjectId();
       await Model.create({ _id: customObjectId, status: 'pending' });
-      await wait();
 
       const logs = await LogHistory.find({ model_id: customObjectId }).lean();
       expect(logs.length).toBe(1);
@@ -320,7 +307,6 @@ describe('mongoose-log-history plugin - Model ID Types (string, number, ObjectId
       const LogHistory = getLogHistoryModel('CustomKeyString', true);
 
       const doc = await Model.create({ customId: 'custom-123', status: 'pending' });
-      await wait();
 
       const logs = await LogHistory.find({ model_id: 'custom-123' }).lean();
       expect(logs.length).toBe(1);
@@ -344,7 +330,6 @@ describe('mongoose-log-history plugin - Model ID Types (string, number, ObjectId
       const LogHistory = getLogHistoryModel('CustomKeyNumber', true);
 
       const doc = await Model.create({ customId: 999, status: 'pending' });
-      await wait();
 
       const logs = await LogHistory.find({ model_id: 999 }).lean();
       expect(logs.length).toBe(1);
@@ -395,7 +380,6 @@ describe('mongoose-log-history plugin - Model ID Types (string, number, ObjectId
       const stringDoc = await StringModel.create({ _id: 'str-001', status: 'pending' });
       const numberDoc = await NumberModel.create({ _id: 5000, status: 'pending' });
       const objectIdDoc = await ObjectIdModel.create({ status: 'pending' });
-      await wait();
 
       // Verify all logs are in the same collection
       const allLogs = await LogHistory.find({}).lean();

--- a/test/integration/nested.integration.test.js
+++ b/test/integration/nested.integration.test.js
@@ -51,15 +51,12 @@ describe('mongoose-log-history plugin - Nested Field Tracking', () => {
     await LogHistory.deleteMany({});
   });
 
-  const wait = () => new Promise((resolve) => setTimeout(resolve, 100));
-
   it('logs edit for nested object field', async () => {
     const order = await Order.create({ customer: { name: 'Alice', address: { city: 'Jakarta', zip: '12345' } } });
     await LogHistory.deleteMany({});
     order.customer.name = 'Bob';
     order.customer.address.city = 'Bandung';
     await order.save();
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
     expect(logs.length).toBe(1);
@@ -73,7 +70,6 @@ describe('mongoose-log-history plugin - Nested Field Tracking', () => {
     await LogHistory.deleteMany({});
     order.customer = { name: 'Alice', address: { city: 'Jakarta', zip: '12345' } };
     await order.save();
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
     expect(logs.length).toBe(1);
@@ -83,7 +79,6 @@ describe('mongoose-log-history plugin - Nested Field Tracking', () => {
 
     order.customer = undefined;
     await order.save();
-    await wait();
 
     const logs2 = await LogHistory.find({ model_id: order._id, change_type: 'update' }).sort({ created_at: -1 }).lean();
     expect(logs2.length).toBeGreaterThanOrEqual(1);
@@ -107,7 +102,6 @@ describe('mongoose-log-history plugin - Nested Field Tracking', () => {
       { sku: 'B', details: { color: 'blue', size: 'L' }, qty: 2 },
     ];
     await order.save();
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
     expect(logs.length).toBe(1);
@@ -125,7 +119,6 @@ describe('mongoose-log-history plugin - Nested Field Tracking', () => {
     order.customer = { name: 'Alice', address: { city: 'Jakarta', zip: '12345' } };
     order.items = [{ sku: 'A', details: { color: 'red', size: 'M' }, qty: 1 }];
     await order.save();
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
     expect(logs.length).toBe(0);
@@ -138,7 +131,6 @@ describe('mongoose-log-history plugin - Nested Field Tracking', () => {
     await LogHistory.deleteMany({});
     order.customer = null;
     await order.save();
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
     expect(logs.length).toBe(1);
@@ -157,7 +149,6 @@ describe('mongoose-log-history plugin - Nested Field Tracking', () => {
       { sku: 'B', details: { color: 'blue', size: 'L' }, qty: 2 },
     ];
     await order.save();
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
     expect(logs.length).toBe(1);
@@ -166,7 +157,6 @@ describe('mongoose-log-history plugin - Nested Field Tracking', () => {
 
     order.items = [{ sku: 'A', details: { color: 'red', size: 'M' }, qty: 1 }];
     await order.save();
-    await wait();
 
     const logs2 = await LogHistory.find({ model_id: order._id, change_type: 'update' }).sort({ created_at: -1 }).lean();
     expect(logs2.length).toBeGreaterThanOrEqual(1);

--- a/test/integration/pluginRemoval.integration.test.js
+++ b/test/integration/pluginRemoval.integration.test.js
@@ -27,13 +27,10 @@ describe('mongoose-log-history plugin - Plugin Removal', () => {
     await LogHistory.deleteMany({});
   });
 
-  const wait = () => new Promise((resolve) => setTimeout(resolve, 100));
-
   it('does not log for model without plugin', async () => {
     const order = await OrderWithoutPlugin.create({ status: 'pending' });
     order.status = 'done';
     await order.save();
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id }).lean();
     expect(logs.length).toBe(0);
@@ -47,7 +44,6 @@ describe('mongoose-log-history plugin - Plugin Removal', () => {
     await orderWith.save();
     orderWithout.status = 'done';
     await orderWithout.save();
-    await wait();
 
     const logsWith = await LogHistory.find({ model_id: orderWith._id }).lean();
     const logsWithout = await LogHistory.find({ model_id: orderWithout._id }).lean();

--- a/test/integration/prune.integration.test.js
+++ b/test/integration/prune.integration.test.js
@@ -26,11 +26,8 @@ describe('mongoose-log-history plugin - Pruning Utility', () => {
     await LogHistory.deleteMany({});
   });
 
-  const wait = () => new Promise((resolve) => setTimeout(resolve, 100));
-
   it('prunes logs older than a given date', async () => {
     const order = await Order.create({ status: 'pending' });
-    await wait();
 
     const oldLog = await LogHistory.findOne({ model_id: order._id });
     const db = mongoose.connection.db;
@@ -40,7 +37,6 @@ describe('mongoose-log-history plugin - Pruning Utility', () => {
 
     order.status = 'done';
     await order.save();
-    await wait();
 
     const deleted = await pruneLogHistory({
       modelName: 'OrderPrune',
@@ -59,7 +55,6 @@ describe('mongoose-log-history plugin - Pruning Utility', () => {
     for (let i = 0; i < 5; i++) {
       order.status = `status${i}`;
       await order.save();
-      await wait();
     }
     let logs = await LogHistory.find({ model_id: order._id }).sort({ created_at: 1 }).lean();
     expect(logs.length).toBe(6);
@@ -80,13 +75,11 @@ describe('mongoose-log-history plugin - Pruning Utility', () => {
   it('prunes logs for a specific modelId', async () => {
     const order1 = await Order.create({ status: 'pending' });
     const order2 = await Order.create({ status: 'pending' });
-    await wait();
 
     order1.status = 'done';
     await order1.save();
     order2.status = 'done';
     await order2.save();
-    await wait();
 
     const deleted = await pruneLogHistory({
       modelName: 'OrderPrune',
@@ -114,7 +107,6 @@ describe('mongoose-log-history plugin - Pruning Utility', () => {
     const order = await Order.create({ status: 'pending' });
     order.status = 'done';
     await order.save();
-    await wait();
 
     const deleted = await pruneLogHistory({
       modelName: 'OrderPrune',

--- a/test/integration/softDelete.integration.test.js
+++ b/test/integration/softDelete.integration.test.js
@@ -32,12 +32,9 @@ describe('mongoose-log-history plugin - Soft Delete', () => {
     await LogHistory.deleteMany({});
   });
 
-  const wait = () => new Promise((resolve) => setTimeout(resolve, 100));
-
   it('logs delete when soft delete field is set via updateOne', async () => {
     const order = await Order.create({ status: 'active' });
     await Order.updateOne({ _id: order._id }, { $set: { status: 'deleted' } });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'delete' }).lean();
     expect(logs.length).toBe(1);
@@ -47,7 +44,6 @@ describe('mongoose-log-history plugin - Soft Delete', () => {
   it('logs delete when soft delete field is set via findOneAndUpdate', async () => {
     const order = await Order.create({ status: 'active' });
     await Order.findOneAndUpdate({ _id: order._id }, { $set: { status: 'deleted' } });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'delete' }).lean();
     expect(logs.length).toBe(1);
@@ -57,7 +53,6 @@ describe('mongoose-log-history plugin - Soft Delete', () => {
     const orders = await Order.insertMany([{ status: 'active' }, { status: 'active' }]);
     await LogHistory.deleteMany({});
     await Order.updateMany({}, { $set: { status: 'deleted' } });
-    await wait();
 
     for (const order of orders) {
       const logs = await LogHistory.find({ model_id: order._id, change_type: 'delete' }).lean();
@@ -69,7 +64,6 @@ describe('mongoose-log-history plugin - Soft Delete', () => {
     const order = await Order.create({ status: 'active' });
     order.status = 'deleted';
     await order.save();
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'delete' }).lean();
     expect(logs.length).toBe(1);
@@ -78,7 +72,6 @@ describe('mongoose-log-history plugin - Soft Delete', () => {
   it('logs delete when soft delete field is set via replaceOne', async () => {
     const order = await Order.create({ status: 'active' });
     await Order.replaceOne({ _id: order._id }, { status: 'deleted' });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'delete' }).lean();
     expect(logs.length).toBe(1);
@@ -87,7 +80,6 @@ describe('mongoose-log-history plugin - Soft Delete', () => {
   it('logs delete when soft delete field is set via findOneAndReplace', async () => {
     const order = await Order.create({ status: 'active' });
     await Order.findOneAndReplace({ _id: order._id }, { status: 'deleted' });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'delete' }).lean();
     expect(logs.length).toBe(1);
@@ -96,7 +88,6 @@ describe('mongoose-log-history plugin - Soft Delete', () => {
   it('does not log delete if soft delete field is set to a different value', async () => {
     const order = await Order.create({ status: 'active' });
     await Order.updateOne({ _id: order._id }, { $set: { status: 'archived' } });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'delete' }).lean();
     expect(logs.length).toBe(0);
@@ -105,7 +96,6 @@ describe('mongoose-log-history plugin - Soft Delete', () => {
   it('does not log delete if soft delete field is missing', async () => {
     const order = await Order.create({ status: 'active' });
     await Order.updateOne({ _id: order._id }, { $unset: { status: '' } });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'delete' }).lean();
     expect(logs.length).toBe(0);
@@ -114,7 +104,6 @@ describe('mongoose-log-history plugin - Soft Delete', () => {
   it('does not log delete if already deleted', async () => {
     const order = await Order.create({ status: 'deleted' });
     await Order.updateOne({ _id: order._id }, { $set: { status: 'deleted' } });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'delete' }).lean();
     expect(logs.length).toBe(0);
@@ -131,7 +120,6 @@ describe('mongoose-log-history plugin - Soft Delete', () => {
     ]);
     await LogHistory.deleteMany({});
     await Order.updateMany({}, { $set: { status: 'deleted' } });
-    await wait();
 
     const logs = await LogHistory.find({ change_type: 'delete' }).lean();
     expect(logs.length).toBe(5);

--- a/test/integration/update.integration.test.js
+++ b/test/integration/update.integration.test.js
@@ -39,13 +39,10 @@ describe('mongoose-log-history plugin - Update Operation (all hooks and edge cas
     await LogHistory.deleteMany({});
   });
 
-  const wait = () => new Promise((resolve) => setTimeout(resolve, 100));
-
   it('logs update via save (doc update)', async () => {
     const order = await Order.create({ status: 'pending' });
     order.status = 'done';
     await order.save();
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
     expect(logs.length).toBe(1);
@@ -61,7 +58,6 @@ describe('mongoose-log-history plugin - Update Operation (all hooks and edge cas
   it('logs update via updateOne', async () => {
     const order = await Order.create({ status: 'pending' });
     await Order.updateOne({ _id: order._id }, { $set: { status: 'done' } });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
     expect(logs.length).toBe(1);
@@ -76,7 +72,6 @@ describe('mongoose-log-history plugin - Update Operation (all hooks and edge cas
   it('logs update via updateOne with upsert (creates doc and logs create)', async () => {
     const upsertId = new mongoose.Types.ObjectId();
     await Order.updateOne({ _id: upsertId }, { $set: { status: 'upserted' } }, { upsert: true });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: upsertId }).lean();
     expect(logs.length).toBe(1);
@@ -88,7 +83,6 @@ describe('mongoose-log-history plugin - Update Operation (all hooks and edge cas
   it('logs update via findOneAndUpdate', async () => {
     const order = await Order.create({ status: 'pending' });
     await Order.findOneAndUpdate({ _id: order._id }, { $set: { status: 'done' } });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
     expect(logs.length).toBe(1);
@@ -103,7 +97,6 @@ describe('mongoose-log-history plugin - Update Operation (all hooks and edge cas
   it('logs update via findOneAndUpdate with upsert (creates doc and logs create)', async () => {
     const upsertId = new mongoose.Types.ObjectId();
     await Order.findOneAndUpdate({ _id: upsertId }, { $set: { status: 'upserted' } }, { upsert: true });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: upsertId }).lean();
     expect(logs.length).toBe(1);
@@ -116,7 +109,6 @@ describe('mongoose-log-history plugin - Update Operation (all hooks and edge cas
     const order1 = await Order.create({ status: 'pending' });
     const order2 = await Order.create({ status: 'pending' });
     await Order.updateMany({}, { $set: { status: 'done' } });
-    await wait();
 
     const logs1 = await LogHistory.find({ model_id: order1._id, change_type: 'update' }).lean();
     const logs2 = await LogHistory.find({ model_id: order2._id, change_type: 'update' }).lean();
@@ -131,7 +123,6 @@ describe('mongoose-log-history plugin - Update Operation (all hooks and edge cas
   it('logs update via replaceOne', async () => {
     const order = await Order.create({ status: 'pending' });
     await Order.replaceOne({ _id: order._id }, { status: 'done' });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
     expect(logs.length).toBe(1);
@@ -146,7 +137,6 @@ describe('mongoose-log-history plugin - Update Operation (all hooks and edge cas
   it('logs update via findOneAndReplace', async () => {
     const order = await Order.create({ status: 'pending' });
     await Order.findOneAndReplace({ _id: order._id }, { status: 'done' });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
     expect(logs.length).toBe(1);
@@ -161,7 +151,6 @@ describe('mongoose-log-history plugin - Update Operation (all hooks and edge cas
   it('does not log when updating to the same value (no-op)', async () => {
     const order = await Order.create({ status: 'pending' });
     await Order.updateOne({ _id: order._id }, { $set: { status: 'pending' } });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
     expect(logs.length).toBe(0);
@@ -170,7 +159,6 @@ describe('mongoose-log-history plugin - Update Operation (all hooks and edge cas
   it('does not log when updating untracked fields', async () => {
     const order = await Order.create({ status: 'pending' });
     await Order.updateOne({ _id: order._id }, { $set: { tags: ['a', 'b'] } });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
     expect(logs.length).toBe(0);
@@ -179,7 +167,6 @@ describe('mongoose-log-history plugin - Update Operation (all hooks and edge cas
   it('handles update with null/undefined values', async () => {
     const order = await Order.create({ status: 'pending' });
     await Order.updateOne({ _id: order._id }, { $set: { status: null } });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
     expect(logs.length).toBe(1);
@@ -190,7 +177,6 @@ describe('mongoose-log-history plugin - Update Operation (all hooks and edge cas
     const order = await Order.create({ status: 'pending' });
     const bigString = 'x'.repeat(10000);
     await Order.updateOne({ _id: order._id }, { $set: { status: bigString } });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
     expect(logs.length).toBe(1);
@@ -200,7 +186,6 @@ describe('mongoose-log-history plugin - Update Operation (all hooks and edge cas
   it('handles update with missing/invalid input gracefully', async () => {
     const order = await Order.create({ status: 'pending' });
     await Order.updateOne({ _id: order._id }, {});
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
     expect(logs.length).toBe(0);

--- a/test/integration/userExtraction.integration.test.js
+++ b/test/integration/userExtraction.integration.test.js
@@ -9,8 +9,6 @@ describe('mongoose-log-history plugin - User Extraction', () => {
     }
   });
 
-  const wait = () => new Promise((resolve) => setTimeout(resolve, 100));
-
   it('extracts user from userField (dot notation, nested)', async () => {
     const schema = new mongoose.Schema({
       status: String,
@@ -33,7 +31,6 @@ describe('mongoose-log-history plugin - User Extraction', () => {
       status: 'pending',
       user: { name: 'Alice', email: 'alice@example.com' },
     });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'create' }).lean();
     expect(logs.length).toBe(1);
@@ -59,7 +56,6 @@ describe('mongoose-log-history plugin - User Extraction', () => {
       status: 'pending',
       updated_by: 'Bob',
     });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'create' }).lean();
     expect(logs.length).toBe(1);
@@ -88,7 +84,6 @@ describe('mongoose-log-history plugin - User Extraction', () => {
       { $set: { status: 'done' } },
       { context: { user: 'ContextUser' } }
     );
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
     expect(logs.length).toBe(1);
@@ -117,7 +112,6 @@ describe('mongoose-log-history plugin - User Extraction', () => {
       status: 'pending',
       created_by: { id: new mongoose.Types.ObjectId(), name: 'Fallback', role: 'admin' },
     });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'create' }).lean();
     expect(logs.length).toBe(1);
@@ -142,7 +136,6 @@ describe('mongoose-log-history plugin - User Extraction', () => {
       status: 'pending',
       updated_by: 'UpdatedFallback',
     });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'create' }).lean();
     expect(logs.length).toBe(1);
@@ -167,7 +160,6 @@ describe('mongoose-log-history plugin - User Extraction', () => {
       status: 'pending',
       modified_by: 'ModifiedFallback',
     });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'create' }).lean();
     expect(logs.length).toBe(1);
@@ -190,7 +182,6 @@ describe('mongoose-log-history plugin - User Extraction', () => {
     const order = await OrderNoUser.create({
       status: 'pending',
     });
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'create' }).lean();
     expect(logs.length).toBe(1);
@@ -224,7 +215,6 @@ describe('mongoose-log-history plugin - User Extraction', () => {
       { $set: { status: 'done' } },
       { context: { user: 'ContextWins' } }
     );
-    await wait();
 
     const logs = await LogHistory.find({ model_id: order._id, change_type: 'update' }).lean();
     expect(logs.length).toBe(1);


### PR DESCRIPTION
The calls to `await wait();` in the tests don't seem to be necessary.  Tests pass without them.  Removing these wait calls speeds up test runs.