### PR TITLE
feat: Handle plugin field that dont exists in model schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Model.create(doc, { strict: false });
 3. **Pass user/context via `$locals` or query context** (no schema change).
 
 ```js
+// Make sure you used contructor method ot create the data to make sure the $locals works
 const doc = new Model({ title: 'Post' });
 doc.$locals.created_by = { id: userId, name: 'Alice' };
 await doc.save();

--- a/README.md
+++ b/README.md
@@ -215,6 +215,42 @@ userField: 'userId'; // Use doc.userId
 
 ---
 
+### Missing schema fields
+
+Mongoose removes keys that are not defined in the schema. If you configure `trackedFields`, `contextFields`, `userField`, `modelKeyId`, or `softDelete.field` with paths that are not present in the schema, those values may be stripped before the plugin can read them.
+
+**Solutions:**
+
+1. **Add the field to your schema** (recommended).
+
+```js
+const schema = new Schema({
+  created_by: Schema.Types.Mixed,
+  // ...other fields
+});
+```
+
+2. **Disable strict mode** (schema‑level or per operation).
+
+```js
+schema.set('strict', false);
+// or
+Model.create(doc, { strict: false });
+```
+
+3. **Pass user/context via `$locals` or query context** (no schema change).
+
+```js
+const doc = new Model({ title: 'Post' });
+doc.$locals.created_by = { id: userId, name: 'Alice' };
+await doc.save();
+
+// For query updates/deletes, pass context
+await Model.updateOne({ _id: id }, { $set: { title: 'Updated' } }, { context: { created_by: user } });
+```
+
+---
+
 ### Soft Delete Option
 
 The `softDelete` option allows you to track "soft deletes"—where a document is marked as deleted by setting a specific field to a certain value, rather than being physically removed from the database.

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1019,15 +1019,21 @@ function collectTrackedFieldPaths(fields: TrackedField[], prefix = ''): string[]
       paths.push(...collectTrackedFieldPaths(field.trackedFields, basePath));
     }
 
-    if (field.contextFields && !Array.isArray(field.contextFields)) {
-      const docFields = field.contextFields.doc ?? [];
-      for (const docField of docFields) {
-        paths.push(docField);
-      }
+    if (field.contextFields) {
+      if (Array.isArray(field.contextFields)) {
+        for (const docField of field.contextFields) {
+          paths.push(docField);
+        }
+      } else {
+        const docFields = field.contextFields.doc ?? [];
+        for (const docField of docFields) {
+          paths.push(docField);
+        }
 
-      const itemFields = field.contextFields.item ?? [];
-      for (const itemField of itemFields) {
-        paths.push(`${basePath}.${itemField}`);
+        const itemFields = field.contextFields.item ?? [];
+        for (const itemField of itemFields) {
+          paths.push(`${basePath}.${itemField}`);
+        }
       }
     }
   }
@@ -1100,6 +1106,12 @@ function hasSchemaPath(schema: mongoose.Schema, path: string): boolean {
 }
 
 function warnIfMissingSchemaPaths(schema: mongoose.Schema, plugin: ChangeLogPlugin): void {
+  const strictMode = schema.get('strict');
+  const shouldWarn = strictMode === true || strictMode === 'throw';
+  if (!shouldWarn) {
+    return;
+  }
+
   const logger = plugin.logger || console;
   const missing = new Set<string>();
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -206,6 +206,14 @@ export class ChangeLogPlugin {
       }
     }
 
+    const locals = (doc as { $locals?: Record<string, unknown> } | null | undefined)?.$locals;
+    if (locals && userField) {
+      const userFromLocals = getValueByPath(locals, userField);
+      if (userFromLocals !== undefined && userFromLocals !== null) {
+        return userFromLocals;
+      }
+    }
+
     if (doc && userField) {
       const userFromDoc = getValueByPath(doc, userField);
       if (userFromDoc !== undefined && userFromDoc !== null) {
@@ -764,6 +772,7 @@ export class ChangeLogPlugin {
 
         const user = self.extractUser({
           doc: doc.toObject(),
+          context: (doc as { $locals?: Record<string, unknown> } | null | undefined)?.$locals,
           userField: self.userField,
         });
 
@@ -844,6 +853,7 @@ export class ChangeLogPlugin {
                 | Types.ObjectId;
               const userData = self.extractUser({
                 doc: doc.toObject ? doc.toObject() : doc,
+                context: (doc as { $locals?: Record<string, unknown> } | null | undefined)?.$locals,
                 userField: self.userField,
               });
 
@@ -990,6 +1000,81 @@ export class ChangeLogPlugin {
   }
 }
 
+function collectTrackedFieldPaths(fields: TrackedField[], prefix = ''): string[] {
+  const paths: string[] = [];
+
+  for (const field of fields) {
+    if (!field?.value) continue;
+    const basePath = prefix ? `${prefix}.${field.value}` : field.value;
+    paths.push(basePath);
+
+    if (field.arrayKey) {
+      paths.push(`${basePath}.${field.arrayKey}`);
+    }
+    if (field.valueField) {
+      paths.push(`${basePath}.${field.valueField}`);
+    }
+
+    if (Array.isArray(field.trackedFields)) {
+      paths.push(...collectTrackedFieldPaths(field.trackedFields, basePath));
+    }
+
+    if (field.contextFields && !Array.isArray(field.contextFields)) {
+      const docFields = field.contextFields.doc ?? [];
+      for (const docField of docFields) {
+        paths.push(docField);
+      }
+
+      const itemFields = field.contextFields.item ?? [];
+      for (const itemField of itemFields) {
+        paths.push(`${basePath}.${itemField}`);
+      }
+    }
+  }
+
+  return paths;
+}
+
+function warnIfMissingSchemaPaths(schema: mongoose.Schema, plugin: ChangeLogPlugin): void {
+  const logger = plugin.logger || console;
+  const missing = new Set<string>();
+
+  const isMissingPath = (path: string): boolean => schema.pathType(path) === 'adhocOrUndefined';
+
+  const trackPaths = collectTrackedFieldPaths(plugin.trackedFields);
+  for (const path of trackPaths) {
+    if (isMissingPath(path)) {
+      missing.add(path);
+    }
+  }
+
+  for (const path of plugin.contextFields ?? []) {
+    if (isMissingPath(path)) {
+      missing.add(path);
+    }
+  }
+
+  if (plugin.userField && isMissingPath(plugin.userField)) {
+    missing.add(plugin.userField);
+  }
+
+  if (plugin.modelKeyId && isMissingPath(plugin.modelKeyId)) {
+    missing.add(plugin.modelKeyId);
+  }
+
+  if (plugin.softDelete?.field && isMissingPath(plugin.softDelete.field)) {
+    missing.add(plugin.softDelete.field);
+  }
+
+  if (missing.size > 0) {
+    logger.warn(
+      `[mongoose-log-history] Some configured fields are not present in the schema and may be stripped by Mongoose: ${[
+        ...missing,
+      ].join(', ')}. See https://github.com/granitebps/mongoose-log-history#missing-schema-fields`
+    );
+  }
+}
+
 /**
  * The main plugin function that can be used with Mongoose schemas.
  * This function creates a plugin instance and attaches all necessary hooks to the schema.
@@ -1003,6 +1088,8 @@ export function changeLoggingPlugin(schema: mongoose.Schema, options: PluginOpti
   }
 
   const pluginInstance = new ChangeLogPlugin({ ...options, modelName: options.modelName });
+
+  warnIfMissingSchemaPaths(schema, pluginInstance);
 
   (schema.statics as Record<string, unknown>).getHistoriesById = async function (
     modelId: string | number | Types.ObjectId,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1035,11 +1035,75 @@ function collectTrackedFieldPaths(fields: TrackedField[], prefix = ''): string[]
   return paths;
 }
 
+function hasSchemaPath(schema: mongoose.Schema, path: string): boolean {
+  if (!path) return false;
+  if (schema.pathType(path) !== 'adhocOrUndefined') return true;
+
+  const segments = path.split('.');
+  let currentSchema: mongoose.Schema | null = schema;
+  let index = 0;
+
+  while (currentSchema && index < segments.length) {
+    const remainingPath = segments.slice(index).join('.');
+    if (currentSchema.pathType(remainingPath) !== 'adhocOrUndefined') {
+      return true;
+    }
+
+    const segment = segments[index];
+    const schemaType = currentSchema.path(segment) as
+      | (mongoose.SchemaType & {
+          schema?: mongoose.Schema;
+          $embeddedSchemaType?: { schema?: mongoose.Schema };
+          $isMongooseMap?: boolean;
+          $__schemaType?: { schema?: mongoose.Schema };
+        })
+      | undefined;
+
+    if (!schemaType) {
+      return false;
+    }
+
+    if (index === segments.length - 1) {
+      return true;
+    }
+
+    if (schemaType.schema) {
+      currentSchema = schemaType.schema;
+      index += 1;
+      continue;
+    }
+
+    if (schemaType.$embeddedSchemaType?.schema) {
+      currentSchema = schemaType.$embeddedSchemaType.schema;
+      index += 1;
+      continue;
+    }
+
+    if (schemaType.$isMongooseMap) {
+      const mapValueSchema = schemaType.$__schemaType?.schema;
+      if (!mapValueSchema) {
+        return true;
+      }
+
+      index += 2;
+      if (index >= segments.length) {
+        return true;
+      }
+      currentSchema = mapValueSchema;
+      continue;
+    }
+
+    return false;
+  }
+
+  return false;
+}
+
 function warnIfMissingSchemaPaths(schema: mongoose.Schema, plugin: ChangeLogPlugin): void {
   const logger = plugin.logger || console;
   const missing = new Set<string>();
 
-  const isMissingPath = (path: string): boolean => schema.pathType(path) === 'adhocOrUndefined';
+  const isMissingPath = (path: string): boolean => !hasSchemaPath(schema, path);
 
   const trackPaths = collectTrackedFieldPaths(plugin.trackedFields);
   for (const path of trackPaths) {

--- a/test/integration/missingFields.integration.test.js
+++ b/test/integration/missingFields.integration.test.js
@@ -111,4 +111,31 @@ describe('mongoose-log-history plugin - Missing schema fields', () => {
     expect(logs.length).toBe(1);
     expect(logs[0].created_by).toEqual({ id: 'u4', name: 'LocalUser' });
   });
+
+  it('does not warn for tracked dotted path inside array of objects', () => {
+    const logger = {
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+
+    const schema = new mongoose.Schema({
+      created_by: mongoose.Schema.Types.Mixed,
+      invoices_address: [
+        {
+          street: String,
+          city: String,
+        },
+      ],
+    });
+
+    schema.plugin(changeLoggingPlugin, {
+      modelName: 'MissingFieldArrayNestedPath',
+      trackedFields: [{ value: 'invoices_address.street' }],
+      singleCollection: true,
+      userField: 'created_by',
+      logger,
+    });
+
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
 });

--- a/test/integration/missingFields.integration.test.js
+++ b/test/integration/missingFields.integration.test.js
@@ -1,0 +1,114 @@
+require('../setup/mongodb');
+const mongoose = require('mongoose');
+const { changeLoggingPlugin, getLogHistoryModel } = require('../../dist');
+
+describe('mongoose-log-history plugin - Missing schema fields', () => {
+  const wait = () => new Promise((resolve) => setTimeout(resolve, 100));
+
+  afterEach(async () => {
+    for (const modelName of Object.keys(mongoose.connection.models)) {
+      await mongoose.connection.models[modelName].deleteMany({});
+    }
+  });
+
+  it('strips missing field from payload (strict schema)', async () => {
+    const schema = new mongoose.Schema({
+      title: String,
+    });
+    schema.plugin(changeLoggingPlugin, {
+      modelName: 'MissingFieldStrict',
+      trackedFields: [{ value: 'title' }],
+      singleCollection: true,
+      userField: 'created_by',
+    });
+
+    delete mongoose.connection.models.MissingFieldStrict;
+    const Model = mongoose.model('MissingFieldStrict', schema);
+    const LogHistory = getLogHistoryModel('MissingFieldStrict', true);
+
+    const doc = await Model.create({ title: 'A', created_by: { id: 'u1' } });
+    await wait();
+
+    const fromDb = await Model.findById(doc._id).lean();
+    expect(fromDb.created_by).toBeUndefined();
+
+    const logs = await LogHistory.find({ model_id: doc._id, change_type: 'create' }).lean();
+    expect(logs.length).toBe(1);
+    expect(logs[0].created_by).toBeNull();
+  });
+
+  it('works when field is added to schema', async () => {
+    const schema = new mongoose.Schema({
+      title: String,
+      created_by: mongoose.Schema.Types.Mixed,
+    });
+    schema.plugin(changeLoggingPlugin, {
+      modelName: 'MissingFieldWithSchema',
+      trackedFields: [{ value: 'title' }],
+      singleCollection: true,
+      userField: 'created_by',
+    });
+
+    delete mongoose.connection.models.MissingFieldWithSchema;
+    const Model = mongoose.model('MissingFieldWithSchema', schema);
+    const LogHistory = getLogHistoryModel('MissingFieldWithSchema', true);
+
+    const payload = { id: 'u2', role: 'admin' };
+    const doc = await Model.create({ title: 'B', created_by: payload });
+    await wait();
+
+    const logs = await LogHistory.find({ model_id: doc._id, change_type: 'create' }).lean();
+    expect(logs.length).toBe(1);
+    expect(logs[0].created_by).toEqual(payload);
+  });
+
+  it('works when strict mode is disabled', async () => {
+    const schema = new mongoose.Schema({
+      title: String,
+    });
+    schema.set('strict', false);
+    schema.plugin(changeLoggingPlugin, {
+      modelName: 'MissingFieldStrictFalse',
+      trackedFields: [{ value: 'title' }],
+      singleCollection: true,
+      userField: 'created_by',
+    });
+
+    delete mongoose.connection.models.MissingFieldStrictFalse;
+    const Model = mongoose.model('MissingFieldStrictFalse', schema);
+    const LogHistory = getLogHistoryModel('MissingFieldStrictFalse', true);
+
+    const payload = { id: 'u3' };
+    const doc = await Model.create({ title: 'C', created_by: payload });
+    await wait();
+
+    const logs = await LogHistory.find({ model_id: doc._id, change_type: 'create' }).lean();
+    expect(logs.length).toBe(1);
+    expect(logs[0].created_by).toEqual(payload);
+  });
+
+  it('works when user is passed via $locals', async () => {
+    const schema = new mongoose.Schema({
+      title: String,
+    });
+    schema.plugin(changeLoggingPlugin, {
+      modelName: 'MissingFieldLocals',
+      trackedFields: [{ value: 'title' }],
+      singleCollection: true,
+      userField: 'created_by',
+    });
+
+    delete mongoose.connection.models.MissingFieldLocals;
+    const Model = mongoose.model('MissingFieldLocals', schema);
+    const LogHistory = getLogHistoryModel('MissingFieldLocals', true);
+
+    const doc = new Model({ title: 'D' });
+    doc.$locals = { created_by: { id: 'u4', name: 'LocalUser' } };
+    await doc.save();
+    await wait();
+
+    const logs = await LogHistory.find({ model_id: doc._id, change_type: 'create' }).lean();
+    expect(logs.length).toBe(1);
+    expect(logs[0].created_by).toEqual({ id: 'u4', name: 'LocalUser' });
+  });
+});


### PR DESCRIPTION
By default, mongoose will use `strict: true` on every model. So, any field that not exists in the schema but added to payload when creating data will be ignored (https://mongoosejs.com/docs/guide.html#strict). This affect `userField` that sometimes not align with the schema. For example, usually we have `created_by` field on the schema because we need to know which user created the data. But, since this plugin already handled that, we dont need the `created_by` field on the schema and removed it from the schema. Because of that, field that we define on `userField` dont exists on the schema, therefore the field got removed by mongoose on some of pre hooks. This PR will handle that issue using several ways, look at https://github.com/granitebps/mongoose-log-history#missing-schema-fields