### PR TITLE
fix: prevent prototype pollution in setByPath

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -183,8 +183,17 @@ export function getValueByPath(obj: Record<string, unknown> | null | undefined, 
  * @param path - The dot-notated path (e.g., 'a.b.c').
  * @param value - The value to set.
  */
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 export function setByPath(obj: Record<string, unknown>, path: string, value: unknown): void {
   const parts = path.split('.');
+
+  for (const part of parts) {
+    if (UNSAFE_KEYS.has(part)) {
+      return;
+    }
+  }
+
   let current: Record<string, unknown> = obj;
   for (let i = 0; i < parts.length - 1; i++) {
     if (!current[parts[i]] || typeof current[parts[i]] !== 'object') {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -183,13 +183,17 @@ export function getValueByPath(obj: Record<string, unknown> | null | undefined, 
  * @param path - The dot-notated path (e.g., 'a.b.c').
  * @param value - The value to set.
  */
-const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+const UNSAFE_KEYS = new Set(['__proto__']);
 
 export function setByPath(obj: Record<string, unknown>, path: string, value: unknown): void {
   const parts = path.split('.');
 
-  for (const part of parts) {
-    if (UNSAFE_KEYS.has(part)) {
+  for (let i = 0; i < parts.length; i++) {
+    if (UNSAFE_KEYS.has(parts[i])) {
+      return;
+    }
+
+    if (parts[i] === 'constructor' && parts[i + 1] === 'prototype') {
       return;
     }
   }

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -180,6 +180,35 @@ describe('utils', () => {
       setByPath(obj, 'x.y.z', 'test');
       expect(obj.x.y.z).toBe('test');
     });
+    it('ignores __proto__ at first segment and does not pollute', () => {
+      delete Object.prototype.polluted;
+      const obj = {};
+      setByPath(obj, '__proto__.polluted', 'yes');
+      expect({}.polluted).toBeUndefined();
+      expect(Object.prototype.polluted).toBeUndefined();
+      expect(obj).toEqual({});
+    });
+    it('ignores __proto__ at nested segment and does not pollute', () => {
+      delete Object.prototype.polluted;
+      const obj = {};
+      setByPath(obj, 'a.__proto__.polluted', 'yes');
+      expect({}.polluted).toBeUndefined();
+      expect(Object.prototype.polluted).toBeUndefined();
+      expect(obj).toEqual({});
+    });
+    it('ignores constructor.prototype traversal and does not pollute', () => {
+      delete Object.prototype.polluted;
+      const obj = {};
+      setByPath(obj, 'a.constructor.prototype.polluted', 'yes');
+      expect({}.polluted).toBeUndefined();
+      expect(Object.prototype.polluted).toBeUndefined();
+      expect(obj).toEqual({});
+    });
+    it('still sets safe nested paths normally after hardening', () => {
+      const obj = {};
+      setByPath(obj, 'safe.nested.value', 123);
+      expect(obj).toEqual({ safe: { nested: { value: 123 } } });
+    });
   });
 
   describe('valueToString', () => {

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -180,6 +180,16 @@ describe('utils', () => {
       setByPath(obj, 'x.y.z', 'test');
       expect(obj.x.y.z).toBe('test');
     });
+    it('allows constructor as a normal nested field name', () => {
+      const obj = {};
+      setByPath(obj, 'metadata.constructor.name', 'Widget');
+      expect(obj).toEqual({ metadata: { constructor: { name: 'Widget' } } });
+    });
+    it('allows prototype as a normal nested field name', () => {
+      const obj = {};
+      setByPath(obj, 'metadata.prototype.version', 1);
+      expect(obj).toEqual({ metadata: { prototype: { version: 1 } } });
+    });
     it('ignores __proto__ at first segment and does not pollute', () => {
       delete Object.prototype.polluted;
       const obj = {};


### PR DESCRIPTION
Closed https://github.com/granitebps/mongoose-log-history/issues/20