### PR TITLE
feat: add logConnection option for custom log history connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,30 @@ orderSchema.plugin(changeLoggingPlugin, {
 const Order = mongoose.model('Order', orderSchema);
 ```
 
+### Custom Log Connection
+
+Use `logConnection` when your audit logs should be stored in a different MongoDB connection than your main model data.
+
+```js
+const mongoose = require('mongoose');
+const { changeLoggingPlugin } = require('mongoose-log-history');
+
+const appConnection = await mongoose.createConnection(process.env.MONGO_URI).asPromise();
+const auditConnection = await mongoose.createConnection(process.env.AUDIT_MONGO_URI).asPromise();
+
+const orderSchema = new mongoose.Schema({
+  status: String,
+});
+
+orderSchema.plugin(changeLoggingPlugin, {
+  modelName: 'order',
+  trackedFields: [{ value: 'status' }],
+  logConnection: auditConnection,
+});
+
+const Order = appConnection.model('Order', orderSchema);
+```
+
 ### TypeScript Example
 
 ```typescript
@@ -585,7 +609,7 @@ const logEntry = buildLogEntry(
 
 ---
 
-#### `getLogHistoryModel(modelName, singleCollection)`
+#### `getLogHistoryModel(modelName, singleCollection, logConnection)`
 
 Returns the Mongoose model instance for the log history collection (either single or per-model).
 
@@ -596,6 +620,9 @@ const { getLogHistoryModel } = require('mongoose-log-history');
 
 const LogHistory = getLogHistoryModel('Order', true); // true for singleCollection
 await LogHistory.create(logEntry);
+
+const AuditLogHistory = getLogHistoryModel('Order', false, auditConnection);
+const auditLogs = await AuditLogHistory.find({ model_id: orderId });
 ```
 
 ---
@@ -650,6 +677,16 @@ await pruneLogHistory({
   singleCollection: true,
   keepLast: 50,
   modelId: '60f7c2b8e1b1c8a1b8e1b1c8',
+});
+```
+
+**Prune logs from a custom log connection:**
+
+```js
+await pruneLogHistory({
+  modelName: 'Order',
+  logConnection: auditConnection,
+  before: '30d',
 });
 ```
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -162,6 +162,7 @@ export class ChangeLogPlugin {
   public readonly batchSize: number;
   public readonly logger: Logger;
   public readonly userField: string;
+  public readonly logConnection?: mongoose.Connection;
   public readonly compressDocs: boolean;
 
   constructor(options: PluginOptions & { modelName: string }) {
@@ -178,6 +179,7 @@ export class ChangeLogPlugin {
     this.batchSize = options.batchSize ?? 100;
     this.logger = options.logger ?? console;
     this.userField = options.userField ?? 'created_by';
+    this.logConnection = options.logConnection;
     this.compressDocs = options.compressDocs === true;
   }
 
@@ -186,7 +188,7 @@ export class ChangeLogPlugin {
    * @returns The log history model for this plugin configuration.
    */
   public getLogHistoryModelPlugin(): LogHistoryModel {
-    return getLogHistoryModel(this.modelName, this.singleCollection);
+    return getLogHistoryModel(this.modelName, this.singleCollection, this.logConnection);
   }
 
   /**

--- a/src/prune.ts
+++ b/src/prune.ts
@@ -1,6 +1,6 @@
 import { getLogHistoryModel } from './schema';
 import { parseHumanTime } from './utils';
-import { Types } from 'mongoose';
+import { Connection, Types } from 'mongoose';
 
 /**
  * Options for pruning log history entries.
@@ -11,6 +11,7 @@ export interface PruneOptions {
   before?: Date | string | number;
   keepLast?: number;
   modelId?: string | number | Types.ObjectId | unknown;
+  logConnection?: Connection;
 }
 
 /**
@@ -26,8 +27,9 @@ export async function pruneLogHistory({
   before,
   keepLast,
   modelId,
+  logConnection,
 }: PruneOptions): Promise<number> {
-  const LogHistory = getLogHistoryModel(modelName as string, singleCollection);
+  const LogHistory = getLogHistoryModel(modelName as string, singleCollection, logConnection);
 
   const query: Record<string, unknown> = {};
   if (before) {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -119,17 +119,30 @@ logHistorySchema.index({
  *
  * @param modelName - The name of the model being tracked.
  * @param singleCollection - Whether to use a single collection for all models or separate collections.
+ * @param logConnection - Optional Mongoose connection used to store and read log history instead of default connection.
  * @returns The Mongoose model for log history operations.
  */
-export function getLogHistoryModel(modelName: string, singleCollection = false): LogHistoryModel {
-  const collectionName = singleCollection ? 'log_histories' : `log_histories_${modelName}`;
-  const modelKey = singleCollection ? 'LogHistory' : `LogHistory_${modelName}`;
-
-  if (mongoose.models[modelKey]) {
-    return mongoose.models[modelKey] as LogHistoryModel;
+export function getLogHistoryModel(
+  modelName: string,
+  singleCollection = false,
+  logConnection?: mongoose.Connection
+): LogHistoryModel {
+  if (
+    logConnection !== undefined &&
+    (!logConnection || typeof logConnection.model !== 'function' || typeof logConnection.collection !== 'function')
+  ) {
+    throw new Error('[mongoose-log-history] "logConnection" must be a valid Mongoose connection.');
   }
 
-  return mongoose.model<LogHistoryDocument, LogHistoryModel>(modelKey, logHistorySchema, collectionName);
+  const collectionName = singleCollection ? 'log_histories' : `log_histories_${modelName}`;
+  const modelKey = singleCollection ? 'LogHistory' : `LogHistory_${modelName}`;
+  const connection = logConnection ?? mongoose.connection;
+
+  if (connection.models[modelKey]) {
+    return connection.models[modelKey] as LogHistoryModel;
+  }
+
+  return connection.model<LogHistoryDocument, LogHistoryModel>(modelKey, logHistorySchema, collectionName);
 }
 
 export { logSchema, logHistorySchema };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Document, Model, Types } from 'mongoose';
+import { Connection, Document, Model, Types } from 'mongoose';
 
 /**
  * Supported change types for logging operations.
@@ -147,6 +147,12 @@ export interface PluginOptions {
    * Defaults to console.
    */
   logger?: Logger;
+
+  /**
+   * Optional Mongoose connection used for writing and reading log history.
+   * Defaults to Mongoose's default connection.
+   */
+  logConnection?: Connection;
 
   /**
    * Field path to extract user information from documents or context.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -347,6 +347,15 @@ export function validatePluginOptions(options: PluginOptions & { modelName: stri
     throw new Error('[mongoose-log-history] "modelName" option is required and must be a string.');
   }
 
+  if (
+    options.logConnection !== undefined &&
+    (!options.logConnection ||
+      typeof options.logConnection.model !== 'function' ||
+      typeof options.logConnection.collection !== 'function')
+  ) {
+    throw new Error('[mongoose-log-history] "logConnection" must be a valid Mongoose connection.');
+  }
+
   if (!options.trackedFields || !Array.isArray(options.trackedFields)) {
     throw new Error('[mongoose-log-history] "trackedFields" option must be an array.');
   }

--- a/test/integration/logConnection.integration.test.js
+++ b/test/integration/logConnection.integration.test.js
@@ -1,0 +1,273 @@
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const { changeLoggingPlugin, getLogHistoryModel, pruneLogHistory } = require('../../dist');
+
+describe('mongoose-log-history plugin - Log Connection', () => {
+  let logMongoServer;
+
+  beforeAll(async () => {
+    logMongoServer = await MongoMemoryServer.create();
+  });
+
+  afterAll(async () => {
+    await logMongoServer.stop();
+  });
+
+  it('returns log history model bound to provided logConnection', async () => {
+    const logConn = await mongoose.createConnection(logMongoServer.getUri()).asPromise();
+
+    try {
+      const LogHistory = getLogHistoryModel('OrderHelperLogConn', false, logConn);
+
+      expect(LogHistory.db === logConn).toBe(true);
+      expect(logConn.models.LogHistory_OrderHelperLogConn).toBe(LogHistory);
+      expect(mongoose.models.LogHistory_OrderHelperLogConn).toBeUndefined();
+    } finally {
+      await logConn.close();
+      await logConn.deleteModel(/LogHistory_OrderHelperLogConn/);
+    }
+  });
+
+  it('falls back to default connection when logConnection is omitted', async () => {
+    const logConn = await mongoose.createConnection(logMongoServer.getUri()).asPromise();
+
+    try {
+      const orderSchema = new mongoose.Schema({
+        status: String,
+      });
+
+      orderSchema.plugin(changeLoggingPlugin, {
+        modelName: 'OrderDefaultLogConn',
+        trackedFields: [{ value: 'status' }],
+      });
+
+      const Order = mongoose.model('OrderDefaultLogConn', orderSchema);
+      const doc = await Order.create({ status: 'pending' });
+      await Order.updateOne({ _id: doc._id }, { status: 'paid' });
+
+      const defaultLogs = await getLogHistoryModel('OrderDefaultLogConn').find({ model_id: doc._id });
+      const defaultLogModel = mongoose.connection.models.LogHistory_OrderDefaultLogConn;
+      const histories = await Order.getHistoriesById(doc._id);
+      const customLogs = await getLogHistoryModel('OrderDefaultLogConn', false, logConn).find({ model_id: doc._id });
+      const updateLog = defaultLogs.find((log) => log.change_type === 'update');
+      const historyUpdateLog = histories.find((log) => log.change_type === 'update');
+
+      expect(defaultLogs).toHaveLength(2);
+      expect(updateLog).toBeDefined();
+      expect(updateLog.logs).toHaveLength(1);
+      expect(updateLog.logs[0]).toMatchObject({
+        field_name: 'status',
+        from_value: 'pending',
+        to_value: 'paid',
+      });
+      expect(histories).toHaveLength(2);
+      expect(historyUpdateLog).toBeDefined();
+      expect(historyUpdateLog.logs).toHaveLength(1);
+      expect(historyUpdateLog.logs[0]).toMatchObject({
+        field_name: 'status',
+        from_value: 'pending',
+        to_value: 'paid',
+      });
+      expect(customLogs).toHaveLength(0);
+      expect(defaultLogModel).toBeDefined();
+      expect(defaultLogModel.db === mongoose.connection).toBe(true);
+    } finally {
+      await mongoose.deleteModel(/OrderDefaultLogConn/);
+      await mongoose.deleteModel(/LogHistory_OrderDefaultLogConn/);
+      await logConn.deleteModel(/LogHistory_OrderDefaultLogConn/);
+      await logConn.close();
+    }
+  });
+
+  it('rejects invalid logConnection in helper', () => {
+    expect(() => {
+      getLogHistoryModel('OrderHelperInvalidLogConn', false, {});
+    }).toThrow('[mongoose-log-history] "logConnection" must be a valid Mongoose connection.');
+  });
+
+  it('isolates same model name across default and custom log connections', async () => {
+    const logConn = await mongoose.createConnection(logMongoServer.getUri()).asPromise();
+
+    try {
+      const defaultLogHistory = getLogHistoryModel('OrderSharedLogConn');
+      const customLogHistory = getLogHistoryModel('OrderSharedLogConn', false, logConn);
+
+      expect(defaultLogHistory).not.toBe(customLogHistory);
+      expect(defaultLogHistory.db === mongoose.connection).toBe(true);
+      expect(customLogHistory.db === logConn).toBe(true);
+      expect(mongoose.models.LogHistory_OrderSharedLogConn).toBe(defaultLogHistory);
+      expect(logConn.models.LogHistory_OrderSharedLogConn).toBe(customLogHistory);
+    } finally {
+      await logConn.close();
+      await mongoose.deleteModel(/LogHistory_OrderSharedLogConn/);
+      await logConn.deleteModel(/LogHistory_OrderSharedLogConn/);
+    }
+  });
+
+  it('writes and prunes single-collection log history using a provided logConnection', async () => {
+    const logConn = await mongoose.createConnection(logMongoServer.getUri()).asPromise();
+
+    try {
+      const orderSchema = new mongoose.Schema({
+        status: String,
+      });
+
+      orderSchema.plugin(changeLoggingPlugin, {
+        modelName: 'OrderSingleCollectionLogConn',
+        trackedFields: [{ value: 'status' }],
+        singleCollection: true,
+        logConnection: logConn,
+      });
+
+      const Order = mongoose.model('OrderSingleCollectionLogConn', orderSchema);
+      const doc = await Order.create({ status: 'pending' });
+      await Order.updateOne({ _id: doc._id }, { status: 'paid' });
+
+      const defaultLogs = await getLogHistoryModel('OrderSingleCollectionLogConn', true).find({
+        model: 'OrderSingleCollectionLogConn',
+        model_id: doc._id,
+      });
+      const customLogs = await getLogHistoryModel('OrderSingleCollectionLogConn', true, logConn).find({
+        model: 'OrderSingleCollectionLogConn',
+        model_id: doc._id,
+      });
+      const histories = await Order.getHistoriesById(doc._id);
+      const customUpdateLog = customLogs.find((log) => log.change_type === 'update');
+      const historyUpdateLog = histories.find((log) => log.change_type === 'update');
+
+      expect(customLogs).toHaveLength(2);
+      expect(customUpdateLog).toBeDefined();
+      expect(customUpdateLog.logs).toHaveLength(1);
+      expect(customUpdateLog.logs[0]).toMatchObject({
+        field_name: 'status',
+        from_value: 'pending',
+        to_value: 'paid',
+      });
+      expect(defaultLogs).toHaveLength(0);
+      expect(histories).toHaveLength(2);
+      expect(historyUpdateLog).toBeDefined();
+      expect(historyUpdateLog.logs).toHaveLength(1);
+      expect(historyUpdateLog.logs[0]).toMatchObject({
+        field_name: 'status',
+        from_value: 'pending',
+        to_value: 'paid',
+      });
+
+      const deletedCount = await pruneLogHistory({
+        singleCollection: true,
+        logConnection: logConn,
+      });
+      const prunedCustomLogs = await getLogHistoryModel('OrderSingleCollectionLogConn', true, logConn).find({
+        model: 'OrderSingleCollectionLogConn',
+        model_id: doc._id,
+      });
+
+      expect(deletedCount).toBe(2);
+      expect(prunedCustomLogs).toHaveLength(0);
+    } finally {
+      await mongoose.deleteModel(/OrderSingleCollectionLogConn/);
+      await mongoose.deleteModel('LogHistory');
+      await logConn.deleteModel('LogHistory');
+      await logConn.close();
+    }
+  });
+
+  it('writes log history using a provided logConnection', async () => {
+    const logConn = await mongoose.createConnection(logMongoServer.getUri()).asPromise();
+
+    try {
+      const orderSchema = new mongoose.Schema({
+        status: String,
+      });
+
+      orderSchema.plugin(changeLoggingPlugin, {
+        modelName: 'OrderLogConn',
+        trackedFields: [{ value: 'status' }],
+        logConnection: logConn,
+      });
+
+      const Order = mongoose.model('OrderLogConn', orderSchema);
+      const doc = await Order.create({ status: 'pending' });
+      await Order.updateOne({ _id: doc._id }, { status: 'paid' });
+
+      const defaultLogs = await getLogHistoryModel('OrderLogConn').find({ model_id: doc._id });
+      const customLogs = await getLogHistoryModel('OrderLogConn', false, logConn).find({ model_id: doc._id });
+      const histories = await Order.getHistoriesById(doc._id);
+      const customUpdateLog = customLogs.find((log) => log.change_type === 'update');
+      const historyUpdateLog = histories.find((log) => log.change_type === 'update');
+
+      expect(customLogs).toHaveLength(2);
+      expect(customUpdateLog).toBeDefined();
+      expect(customUpdateLog.logs).toHaveLength(1);
+      expect(customUpdateLog.logs[0]).toMatchObject({
+        field_name: 'status',
+        from_value: 'pending',
+        to_value: 'paid',
+      });
+      expect(histories).toHaveLength(2);
+      expect(historyUpdateLog).toBeDefined();
+      expect(historyUpdateLog.logs).toHaveLength(1);
+      expect(historyUpdateLog.logs[0]).toMatchObject({
+        field_name: 'status',
+        from_value: 'pending',
+        to_value: 'paid',
+      });
+      expect(defaultLogs).toHaveLength(0);
+    } finally {
+      await mongoose.deleteModel(/OrderLogConn/);
+      await mongoose.deleteModel(/LogHistory_OrderLogConn/);
+      await logConn.deleteModel(/LogHistory_OrderLogConn/);
+      await logConn.close();
+    }
+  });
+
+  it('prunes log history using a provided logConnection', async () => {
+    const logConn = await mongoose.createConnection(logMongoServer.getUri()).asPromise();
+
+    try {
+      const orderSchema = new mongoose.Schema({
+        status: String,
+      });
+
+      orderSchema.plugin(changeLoggingPlugin, {
+        modelName: 'OrderPruneLogConn',
+        trackedFields: [{ value: 'status' }],
+        logConnection: logConn,
+      });
+
+      const Order = mongoose.model('OrderPruneLogConn', orderSchema);
+      const doc = await Order.create({ status: 'pending' });
+      await Order.updateOne({ _id: doc._id }, { status: 'paid' });
+
+      const deletedCount = await pruneLogHistory({
+        modelName: 'OrderPruneLogConn',
+        modelId: doc._id,
+        logConnection: logConn,
+      });
+
+      const defaultLogs = await getLogHistoryModel('OrderPruneLogConn').find({ model_id: doc._id });
+      const customLogs = await getLogHistoryModel('OrderPruneLogConn', false, logConn).find({ model_id: doc._id });
+
+      expect(deletedCount).toBe(2);
+      expect(customLogs).toHaveLength(0);
+      expect(defaultLogs).toHaveLength(0);
+    } finally {
+      await mongoose.deleteModel(/OrderPruneLogConn/);
+      await mongoose.deleteModel(/LogHistory_OrderPruneLogConn/);
+      await logConn.deleteModel(/LogHistory_OrderPruneLogConn/);
+      await logConn.close();
+    }
+  });
+
+  it('rejects invalid logConnection during plugin setup', () => {
+    const orderSchema = new mongoose.Schema({ status: String });
+
+    expect(() => {
+      orderSchema.plugin(changeLoggingPlugin, {
+        modelName: 'OrderInvalidLogConn',
+        trackedFields: [{ value: 'status' }],
+        logConnection: {},
+      });
+    }).toThrow('[mongoose-log-history] "logConnection" must be a valid Mongoose connection.');
+  });
+});


### PR DESCRIPTION
Adds an optional logConnection plugin option that routes all log history writes, reads, and pruning to a separate
  Mongoose connection. This is useful when audit logs should be stored in a different MongoDB database than the main
  application data.
  
  Changes:
  
  - PluginOptions: new logConnection?: Connection field
  - getLogHistoryModel(): accepts optional logConnection, resolves model against that connection's cache instead of
  global mongoose.models
  - ChangeLogPlugin: stores and threads logConnection through all log model access, including getHistoriesById()
  - pruneLogHistory(): PruneOptions extended with logConnection
  - Validation added in both validatePluginOptions() and getLogHistoryModel() with a clear error message
  - README: new "Custom Log Connection" usage section and updated helper/prune examples
  
  Behavior when omitted: unchanged — falls back to mongoose.connection as before.
  
  Testing:
  
  - 8 new integration tests covering: custom connection writes, default fallback, getHistoriesById() reads,
  single-collection mode, prune, per-connection model cache isolation, and invalid input rejection