### PR TITLE
fix: handle ObjectId on deepClone

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { Types } from 'mongoose';
 import { ArrayDiff, PluginOptions, TrackedField } from './types';
 
 /**
@@ -411,6 +412,10 @@ export function deepClone<T>(obj: T): T {
 
   if (obj instanceof Date) {
     return new Date(obj.getTime()) as T;
+  }
+
+  if (obj instanceof Types.ObjectId) {
+    return new Types.ObjectId(obj.toHexString()) as T;
   }
 
   if (Array.isArray(obj)) {

--- a/test/integration/saveWholeDoc.integration.test.js
+++ b/test/integration/saveWholeDoc.integration.test.js
@@ -1,0 +1,84 @@
+const mongoose = require('mongoose');
+const { changeLoggingPlugin, getLogHistoryModel } = require('../../dist');
+
+describe('mongoose-log-history plugin - saveWholeDoc', () => {
+  afterEach(async () => {
+    for (const name of Object.keys(mongoose.models)) {
+      if (name.startsWith('SaveWholeDoc')) mongoose.deleteModel(name);
+      if (name.startsWith('LogHistory_SaveWholeDoc')) mongoose.deleteModel(name);
+    }
+  });
+
+  it('preserves ObjectId fields as ObjectId instances in updated_doc on create', async () => {
+    const orgId = new mongoose.Types.ObjectId();
+
+    const schema = new mongoose.Schema({
+      status: String,
+      organisation: mongoose.Schema.Types.ObjectId,
+    });
+
+    schema.plugin(changeLoggingPlugin, {
+      modelName: 'SaveWholeDocCreate',
+      trackedFields: [{ value: 'status' }],
+      saveWholeDoc: true,
+    });
+
+    const Order = mongoose.model('SaveWholeDocCreate', schema);
+    const doc = await Order.create({ status: 'pending', organisation: orgId });
+
+    const LogHistory = getLogHistoryModel('SaveWholeDocCreate');
+    const createLog = await LogHistory.findOne({ model_id: doc._id, change_type: 'create' });
+
+    expect(createLog).not.toBeNull();
+    expect(createLog.updated_doc).not.toBeNull();
+
+    // ObjectId fields must be proper ObjectId instances, not { buffer: { '0': ..., '1': ... } }
+    expect(createLog.updated_doc._id instanceof mongoose.Types.ObjectId).toBe(true);
+    expect(createLog.updated_doc.organisation instanceof mongoose.Types.ObjectId).toBe(true);
+    expect(createLog.updated_doc.organisation.toHexString()).toBe(orgId.toHexString());
+    // buffer must be a real Buffer instance, not a plain object with numeric keys
+    expect(Buffer.isBuffer(createLog.updated_doc.organisation.buffer)).toBe(true);
+  });
+
+  it('preserves ObjectId fields in original_doc and updated_doc on save-based update', async () => {
+    const orgId = new mongoose.Types.ObjectId();
+
+    // Include organisation in trackedFields so it appears in the selective fetch
+    const schema = new mongoose.Schema({
+      status: String,
+      organisation: mongoose.Schema.Types.ObjectId,
+    });
+
+    schema.plugin(changeLoggingPlugin, {
+      modelName: 'SaveWholeDocUpdate',
+      trackedFields: [{ value: 'status' }, { value: 'organisation' }],
+      saveWholeDoc: true,
+    });
+
+    const Order = mongoose.model('SaveWholeDocUpdate', schema);
+    const doc = await Order.create({ status: 'pending', organisation: orgId });
+
+    doc.status = 'paid';
+    await doc.save();
+
+    const LogHistory = getLogHistoryModel('SaveWholeDocUpdate');
+    const updateLog = await LogHistory.findOne({ model_id: doc._id, change_type: 'update' });
+
+    expect(updateLog).not.toBeNull();
+    expect(updateLog.original_doc).not.toBeNull();
+    expect(updateLog.updated_doc).not.toBeNull();
+
+    // ObjectId fields must be proper ObjectId instances, not { buffer: { '0': ..., '1': ... } }
+    expect(updateLog.original_doc._id instanceof mongoose.Types.ObjectId).toBe(true);
+    expect(updateLog.original_doc.organisation instanceof mongoose.Types.ObjectId).toBe(true);
+    expect(updateLog.updated_doc._id instanceof mongoose.Types.ObjectId).toBe(true);
+    expect(updateLog.updated_doc.organisation instanceof mongoose.Types.ObjectId).toBe(true);
+
+    expect(updateLog.original_doc.organisation.toHexString()).toBe(orgId.toHexString());
+    expect(updateLog.updated_doc.organisation.toHexString()).toBe(orgId.toHexString());
+
+    // buffer must be a real Buffer instance, not a plain object with numeric keys
+    expect(Buffer.isBuffer(updateLog.original_doc.organisation.buffer)).toBe(true);
+    expect(Buffer.isBuffer(updateLog.updated_doc.organisation.buffer)).toBe(true);
+  });
+});

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -1,3 +1,4 @@
+const mongoose = require('mongoose');
 const {
   isDate,
   isObject,
@@ -10,6 +11,7 @@ const {
   diffSimpleArray,
   setByPath,
   valueToString,
+  deepClone,
 } = require('../../dist/utils');
 
 describe('utils', () => {
@@ -241,6 +243,58 @@ describe('utils', () => {
       const obj = {};
       obj.self = obj;
       expect(typeof valueToString(obj)).toBe('string');
+    });
+  });
+
+  describe('deepClone', () => {
+    it('clones primitives', () => {
+      expect(deepClone(1)).toBe(1);
+      expect(deepClone('str')).toBe('str');
+      expect(deepClone(null)).toBe(null);
+      expect(deepClone(undefined)).toBe(undefined);
+    });
+
+    it('clones Date as a new Date instance', () => {
+      const d = new Date('2020-01-01T00:00:00.000Z');
+      const cloned = deepClone(d);
+      expect(cloned).toEqual(d);
+      expect(cloned).not.toBe(d);
+      expect(cloned instanceof Date).toBe(true);
+    });
+
+    it('clones ObjectId as a new ObjectId instance with the same value', () => {
+      const id = new mongoose.Types.ObjectId();
+      const cloned = deepClone(id);
+      expect(cloned.toHexString()).toBe(id.toHexString());
+      expect(cloned).not.toBe(id);
+      expect(cloned instanceof mongoose.Types.ObjectId).toBe(true);
+    });
+
+    it('does not serialize ObjectId to { buffer: {...} }', () => {
+      const id = new mongoose.Types.ObjectId();
+      const cloned = deepClone(id);
+      // buffer should be a Buffer instance, not a plain object with numeric keys
+      expect(Buffer.isBuffer(cloned.buffer)).toBe(true);
+      expect(typeof cloned.toHexString).toBe('function');
+    });
+
+    it('clones nested object containing ObjectId fields', () => {
+      const id = new mongoose.Types.ObjectId();
+      const obj = { _id: id, name: 'test', nested: { ref: id } };
+      const cloned = deepClone(obj);
+      expect(cloned._id.toHexString()).toBe(id.toHexString());
+      expect(cloned._id).not.toBe(id);
+      expect(cloned.nested.ref.toHexString()).toBe(id.toHexString());
+      expect(cloned.nested.ref).not.toBe(id);
+    });
+
+    it('clones arrays containing ObjectIds', () => {
+      const id = new mongoose.Types.ObjectId();
+      const arr = [id, { ref: id }];
+      const cloned = deepClone(arr);
+      expect(cloned[0].toHexString()).toBe(id.toHexString());
+      expect(cloned[0]).not.toBe(id);
+      expect(cloned[1].ref.toHexString()).toBe(id.toHexString());
     });
   });
 });


### PR DESCRIPTION
Fixes #22. When `saveWholeDoc: true` was enabled, `ObjectId` fields in `original_doc` and `updated_doc` were serialized into plain objects of the shape `{ buffer: { '0': ..., '1': ... } }` instead of being stored as proper BSON `ObjectId` instances.

**Root cause:**

`deepClone()` in `utils.ts` had no special case for `ObjectId`. Since `ObjectId` is an object, it fell into the generic branch
which iterates `Object.entries()` — exposing the internal `buffer` property and recursively cloning it as a plain object
with numeric keys.

**Fix:**

Added an `ObjectId` check in `deepClone()` before the generic object branch:
```
if (obj instanceof Types.ObjectId) {
  return new Types.ObjectId(obj.toHexString()) as T;
}
```

**Testing:**

- 6 new unit tests for `deepClone` in `test/unit/utils.test.js` covering: primitives, `Date`, `ObjectId` identity/value
preservation, the broken buffer shape regression, nested objects, and arrays containing `ObjectId`s.
- 2 new integration tests in `test/integration/saveWholeDoc.integration.test.js` verifying `ObjectId` fields survive the
full round-trip (create and save-based update).